### PR TITLE
switching syntax highlighting to using rouge instead of pygments

### DIFF
--- a/docs/using-combine-book.adoc
+++ b/docs/using-combine-book.adoc
@@ -13,7 +13,7 @@ v0.1, 2019-06-23
 :imagesdir: images
 //:front-cover-image: image:front-cover.jpg[Front Cover,1050,1600]
 :google-analytics-account: UA-898243-5
-:source-highlighter: pygments
+:source-highlighter: rouge
 :url-issues: https://github.com/heckj/swiftui-notes/issues
 :toc: left
 :toclevels: 4


### PR DESCRIPTION
per https://github.com/asciidoctor/asciidoctor/issues/3347, switching to rogue for syntax highlighting engine in asciidoc