### PR TITLE
beta4 fixes and updates

### DIFF
--- a/SwiftUI-Notes/ContentView.swift
+++ b/SwiftUI-Notes/ContentView.swift
@@ -37,11 +37,11 @@ struct ContentView : View {
         VStack {
             Text(model.foo)
                 .font(.title)
-                .color(.blue)
+                .foregroundColor(.blue)
 
             Text("so here's something simpler")
                 .font(.caption)
-                .color(.black)
+                .foregroundColor(.black)
 
             Spacer()
 

--- a/SwiftUI-Notes/ExampleModel.swift
+++ b/SwiftUI-Notes/ExampleModel.swift
@@ -10,10 +10,11 @@ import SwiftUI
 import Combine
 
 class ExampleModel : BindableObject {
+    typealias PublisherType = PassthroughSubject<Void, Never>
+
+    var willChange = PassthroughSubject<Void, Never>()
+    var didChange = PassthroughSubject<Void, Never>()
 
     var foo: String = "Ola, world!" // { didSet { didChange.send() }}
     var bar: Int = 3 // { didSet { didChange.send() }}
-
-    var didChange = PassthroughSubject<Void, Never>()
-    
 }

--- a/SwiftUI-NotesTests/SwiftUI_CombineTests.swift
+++ b/SwiftUI-NotesTests/SwiftUI_CombineTests.swift
@@ -92,7 +92,7 @@ class SwiftUI_CombineTests: XCTestCase {
 
     func testAnyFuture_CreationAndUse() {
         // A generic Future that always returns <Any>"A result"
-        let goodPlace = Future<Any, Error> { promise in
+        let goodPlace = Future<Any, Never> { promise in
             promise(.success("A result"))
         }
 
@@ -109,7 +109,7 @@ class SwiftUI_CombineTests: XCTestCase {
 
     func testStringFuture_CreationAndUse() {
         // A generic Future that always returns <Any>"A result"
-        let goodPlace = Future<String, Error> { promise in
+        let goodPlace = Future<String, Never> { promise in
             promise(.success("A result"))
         }
 

--- a/UIKit-Combine/HeadingViewController.swift
+++ b/UIKit-Combine/HeadingViewController.swift
@@ -78,9 +78,11 @@ class HeadingViewController: UIViewController {
             .publisher
             .print("headingSubscriber")
             .receive(on: RunLoop.main)
-            .sink { someValue in
-                self.headingLabel.text = String(someValue.trueHeading)
-        }
+            .sink(receiveCompletion: { completion in },
+                  receiveValue: { someValue in
+                    self.headingLabel.text = String(someValue.trueHeading)
+            })
+
         headingSubscriber = AnyCancellable(corelocationsub)
     }
 

--- a/UsingCombineTests/EmptyPublisherTests.swift
+++ b/UsingCombineTests/EmptyPublisherTests.swift
@@ -14,7 +14,7 @@ class EmptyPublisherTests: XCTestCase {
     func testEmptyPublisher() {
         let expectation = XCTestExpectation(description: self.debugDescription)
 
-        let _ = Publishers.Empty<String, Never>()
+        let _ = Empty<String, Never>()
             .sink(receiveCompletion: { completion in
                 print(".sink() received the completion", String(describing: completion))
                 switch completion {

--- a/UsingCombineTests/FuturePublisherTests.swift
+++ b/UsingCombineTests/FuturePublisherTests.swift
@@ -42,7 +42,7 @@ class FuturePublisherTests: XCTestCase {
         }
 
         // driving it by attaching it to .sink
-        let _ = sut.sink(receiveCompletion: { err in
+        let cancellable = sut.sink(receiveCompletion: { err in
             print(".sink() received the completion: ", String(describing: err))
             expectation.fulfill()
         }, receiveValue: { value in
@@ -52,6 +52,7 @@ class FuturePublisherTests: XCTestCase {
 
         wait(for: [expectation], timeout: 5.0)
         XCTAssertTrue(outputValue)
+        XCTAssertNotNil(cancellable)
     }
 
     func testFuturePublisherShowingFailure() {
@@ -69,7 +70,7 @@ class FuturePublisherTests: XCTestCase {
         }
 
         // driving it by attaching it to .sink
-        let _ = sut.sink(receiveCompletion: { err in
+        let cancellable = sut.sink(receiveCompletion: { err in
             print(".sink() received the completion: ", String(describing: err))
             XCTAssertNotNil(err)
             expectation.fulfill()
@@ -79,13 +80,14 @@ class FuturePublisherTests: XCTestCase {
         })
 
         wait(for: [expectation], timeout: 5.0)
+        XCTAssertNotNil(cancellable)
     }
 
     func testFutureWithinAFlatMap() {
         let simplePublisher = PassthroughSubject<String, Never>()
         var outputValue: String? = nil
 
-        let _ = simplePublisher
+        let cancellable = simplePublisher
             .print(self.debugDescription)
             .flatMap { name in
                 return Future<String, Error> { promise in
@@ -106,6 +108,7 @@ class FuturePublisherTests: XCTestCase {
         XCTAssertNil(outputValue)
         simplePublisher.send("one")
         XCTAssertEqual(outputValue, "one foo")
+        XCTAssertNotNil(cancellable)
     }
 
 

--- a/UsingCombineTests/PublisherTests.swift
+++ b/UsingCombineTests/PublisherTests.swift
@@ -32,24 +32,26 @@ class PublisherTests: XCTestCase {
         let expectation = XCTestExpectation(description: self.debugDescription)
         let foo = HoldingStruct()
 
-        let _ = foo.$username
+        let cancellable = foo.$username
             .sink { someString in
                 print("value of username updated to: >>\(someString)<<")
                 expectation.fulfill()
         }
         wait(for: [expectation], timeout: 5.0)
+        XCTAssertNotNil(cancellable)
     }
 
     func testPublishedOnClassInstance() {
         let expectation = XCTestExpectation(description: "async sink test")
         let foo = HoldingClass()
 
-        let _ = foo.$username
+        let cancellable = foo.$username
             .sink { someString in
                 print("value of username updated to: >>\(someString)<<")
                 expectation.fulfill()
         }
         wait(for: [expectation], timeout: 5.0)
+        XCTAssertNotNil(cancellable)
     }
 
     func testPublishedOnStructWithChange() {
@@ -57,7 +59,7 @@ class PublisherTests: XCTestCase {
         var foo = HoldingStruct()
         let q = DispatchQueue(label: self.debugDescription)
 
-        let _ = foo.$username
+        let cancellable = foo.$username
             .sink { someString in
                 print("value of username updated to: >>\(someString)<<")
                 if someString == "redfish" {
@@ -69,6 +71,7 @@ class PublisherTests: XCTestCase {
             foo.username = "redfish"
         }
         wait(for: [expectation], timeout: 5.0)
+        XCTAssertNotNil(cancellable)
     }
 
     func testPublishedOnClassWithChange() {
@@ -76,7 +79,7 @@ class PublisherTests: XCTestCase {
         let foo = HoldingClass()
         let q = DispatchQueue(label: self.debugDescription)
 
-        let _ = foo.$username
+        let cancellable = foo.$username
             .sink { someString in
                 print("value of username updated to: >>\(someString)<<")
                 if someString == "redfish" {
@@ -88,6 +91,7 @@ class PublisherTests: XCTestCase {
             foo.username = "redfish"
         }
         wait(for: [expectation], timeout: 5.0)
+        XCTAssertNotNil(cancellable)
     }
 
     func testPublishedOnClassWithTwoSubscribers() {
@@ -132,7 +136,7 @@ class PublisherTests: XCTestCase {
         let foo = HoldingClass()
         let q = DispatchQueue(label: self.debugDescription)
 
-        let _ = foo.$username
+        let cancellable = foo.$username
             .print(self.debugDescription)
             .tryMap({ myValue -> String in
                 if (myValue == "boom") {
@@ -173,6 +177,7 @@ class PublisherTests: XCTestCase {
         })
         wait(for: [expectation], timeout: 5.0)
         XCTAssertEqual(foo.username, "bluefish")
+        XCTAssertNotNil(cancellable)
     }
 
     func testKVOPublisher() {
@@ -180,7 +185,7 @@ class PublisherTests: XCTestCase {
         let foo = KVOAbleNSObject()
         let q = DispatchQueue(label: self.debugDescription)
 
-        let _ = foo.publisher(for: \.intValue)
+        let cancellable = foo.publisher(for: \.intValue)
             .print()
             .sink { someValue in
                 print("value of intValue updated to: >>\(someValue)<<")
@@ -192,6 +197,7 @@ class PublisherTests: XCTestCase {
             expectation.fulfill()
         })
         wait(for: [expectation], timeout: 5.0)
+        XCTAssertNotNil(cancellable)
     }
 
 }

--- a/UsingCombineTests/RetryPublisherTests.swift
+++ b/UsingCombineTests/RetryPublisherTests.swift
@@ -115,7 +115,8 @@ class RetryPublisherTests: XCTestCase {
 
     func testRetryWithOneShotFailPublisher() {
         // setup
-        let _ = Publishers.Fail(outputType: String.self, failure: testFailureCondition.invalidServerResponse)
+
+        let _ = Fail(outputType: String.self, failure: testFailureCondition.invalidServerResponse)
             .print("(1)>")
             .retry(3)
             .print("(2)>")

--- a/UsingCombineTests/SinkSubscriberTests.swift
+++ b/UsingCombineTests/SinkSubscriberTests.swift
@@ -52,7 +52,7 @@ class SinkSubscriberTests: XCTestCase {
         // setup
         let simplePublisher = PassthroughSubject<String, Error>()
 
-        let _ = simplePublisher
+        let cancellable = simplePublisher
             .sink(receiveCompletion: { completion in
                 countCompletionsReceived += 1
                 switch completion {
@@ -79,6 +79,7 @@ class SinkSubscriberTests: XCTestCase {
             })
 
         // validate
+        XCTAssertNotNil(cancellable)
         XCTAssertEqual(countValuesReceived, 0)
         XCTAssertEqual(countCompletionsReceived, 0)
 

--- a/UsingCombineTests/SwitchAndFlatMapPublisherTests.swift
+++ b/UsingCombineTests/SwitchAndFlatMapPublisherTests.swift
@@ -258,7 +258,7 @@ class SwitchAndFlatMapPublisherTests: XCTestCase {
         var countOfResponses = 0
         let simpleSubjectPublisher = PassthroughSubject<String, Never>()
 
-        let _ = simpleSubjectPublisher
+        let cancellable = simpleSubjectPublisher
             .map { stringValue in
                 return APIDifferentProxyExample()
             }
@@ -279,6 +279,8 @@ class SwitchAndFlatMapPublisherTests: XCTestCase {
                 countOfResponses += 1
             })
 
+        XCTAssertNotNil(cancellable)
+        
         XCTAssertEqual(countOfResponses, 0)
         simpleSubjectPublisher.send("trigger")
         XCTAssertEqual(countOfResponses, 2)

--- a/UsingCombineTests/debounceAndRemoveDuplicatesPublisherTests.swift
+++ b/UsingCombineTests/debounceAndRemoveDuplicatesPublisherTests.swift
@@ -17,7 +17,7 @@ class debounceAndRemoveDuplicatesPublisherTests: XCTestCase {
         var mostRecentlyReceivedValue: String? = nil
         var receivedValueCount = 0
 
-        let _ = simplePublisher
+        let cancellable = simplePublisher
             .removeDuplicates()
             .print(self.debugDescription)
             .sink(receiveCompletion: { completion in
@@ -65,6 +65,7 @@ class debounceAndRemoveDuplicatesPublisherTests: XCTestCase {
         XCTAssertEqual(receivedValueCount, 3)
 
         simplePublisher.send(completion: Subscribers.Completion.finished)
+        XCTAssertNotNil(cancellable)
     }
 
 
@@ -78,7 +79,7 @@ class debounceAndRemoveDuplicatesPublisherTests: XCTestCase {
         var mostRecentlyReceivedValue: AnExampleStruct? = nil
         var receivedValueCount = 0
 
-        let _ = simplePublisher
+        let cancellable = simplePublisher
             .removeDuplicates(by: { first, second -> Bool in
                 first.id == second.id
             })
@@ -128,6 +129,7 @@ class debounceAndRemoveDuplicatesPublisherTests: XCTestCase {
         XCTAssertEqual(receivedValueCount, 3)
 
         simplePublisher.send(completion: Subscribers.Completion.finished)
+        XCTAssertNotNil(cancellable)
     }
 
     func testTryRemoveDuplicates() {
@@ -145,7 +147,7 @@ class debounceAndRemoveDuplicatesPublisherTests: XCTestCase {
         var receivedValueCount = 0
         var receivedError = false
 
-        let _ = simplePublisher
+        let cancellable = simplePublisher
             .tryRemoveDuplicates(by: { first, second -> Bool in
                 if (first.id == 5 || second.id == 5) {
                     // a contrived example showing the exception
@@ -207,6 +209,7 @@ class debounceAndRemoveDuplicatesPublisherTests: XCTestCase {
         XCTAssertTrue(receivedError)
 
         simplePublisher.send(completion: Subscribers.Completion.finished)
+        XCTAssertNotNil(cancellable)
     }
 
     func testDebounce() {
@@ -220,7 +223,7 @@ class debounceAndRemoveDuplicatesPublisherTests: XCTestCase {
         let foo = HoldingClass()
         var receivedCount = 0
 
-        let _ = foo.$intValue
+        let cancellable = foo.$intValue
             .debounce(for: 0.5, scheduler: q)
             .print(self.debugDescription)
             .sink { someValue in
@@ -254,6 +257,7 @@ class debounceAndRemoveDuplicatesPublisherTests: XCTestCase {
 
         XCTAssertEqual(receivedCount, 2)
         XCTAssertEqual(foo.intValue, 10)
+        XCTAssertNotNil(cancellable)
     }
 
     func testThrottleLatestFalse() {
@@ -268,7 +272,7 @@ class debounceAndRemoveDuplicatesPublisherTests: XCTestCase {
         var receivedCount = 0
         var lastReceivedSinkValue = -1
 
-        let _ = foo.$intValue
+        let cancellable = foo.$intValue
             .throttle(for: 0.5, scheduler: q, latest: false)
             .print(self.debugDescription)
             .sink { someValue in
@@ -305,6 +309,7 @@ class debounceAndRemoveDuplicatesPublisherTests: XCTestCase {
         // of the values send at 1.1 and 1.2 seconds in, the first value is returned down the pipeline
         XCTAssertEqual(lastReceivedSinkValue, 3)
         XCTAssertEqual(foo.intValue, 4)
+        XCTAssertNotNil(cancellable)
     }
 
     func testThrottleLatestTrue() {

--- a/docs/pattern-cascading-update-interface.adoc
+++ b/docs/pattern-cascading-update-interface.adoc
@@ -59,8 +59,7 @@ Because they are defined on the class instance, the swift compiler creates initi
 
 [NOTE]
 ====
-I *think* the above statement is true related to memory management and cancelling the pipelines, but I have not confirmed it.
-Additionally, a lot of folks comfortable with RxSwift operators are using a "CancelBag" object to collect cancellable references, and cancel the pipelines on tear down.
+A number of developers comfortable with RxSwift are using a "CancelBag" object to collect cancellable references, and cancel the pipelines on tear down.
 An example of this can be seen at https://github.com/tailec/CombineExamples/blob/master/CombineExamples/Shared/CancellableBag.swift
 ====
 

--- a/docs/reference.adoc
+++ b/docs/reference.adoc
@@ -1849,32 +1849,55 @@ __Usage__::
 
 __Details__::
 
-The simplest form of `.sink()` takes a single closure - by default this closure receives data (if provided by the attached publisher).
+There are two forms of the sink operator.
+The first is the simplest form, taking a single closure, receiving only the values from the pipeline (if and when provided by the publisher).
+Using the simpler version comes with a constraint: the failure type of the pipeline must be `<Never>`.
+If you are working with a pipeline that has a failure type other than `<Never>`, you need to use the two closure version, or add error handling into the pipeline itself.
+
+An example of the simple form of sink:
 
 [source, swift]
 ----
 let examplePublisher = Just(5)
 
+let cancellable = examplePublisher.sink { value in
+    print(".sink() received \(String(describing: value))")
+}
+----
+
+Be aware that the closure may be called repeatedly.
+How often it is called depends on the pipeline to which it is subscribing.
+The closure you provide is invoked for every update that the publisher passes down, up until the completion, and prior to any cancellation.
+
+[WARNING]
+====
+It may be tempting to ignore the cancellable you get returned from sink.
+For example, the code:
+
+[source, swift]
+----
 let _ = examplePublisher.sink { value in
     print(".sink() received \(String(describing: value))")
 }
 ----
 
-The closure you provide is invoked for every update that the publisher passes down, up until the completion.
-Be aware that the single closure form may be called repeatedly.
-How often it is called depends on the pipeline to which it is subscribing.
+However, this has the side effect that the as soon as the function returns, the ignore variable is deallocated, causing the pipeline to be cancelled.
+If you want the pipeline to operate beyond the scope of the function (you probably do), then assign it to a longer lived variable that doesn't get deallocated until much later.
+Simple including a variable declaration in the enclosing object is often a good solution.
+====
 
-If you don't also include a closure to get the completion, you will not receive any information about failures.
-If an error or failure occurs and is handed down from the publisher the single closure form will not be called.
+The second form of sink takes two closures, the first of which receives the data from the pipeline, and the second receives pipeline completion messages.
+te a sink with two closures.
+The closures parameters are  `receiveCompletion` and `receiveValue`:
+The .failure completion may also encapsulate an error.
 
-If you are creating a subscriber and want to receive failures, or see the completion messages at the end of pipeline, create a sink with two closures.
-The more complete sink has the two closures named `receiveCompletion` and `receiveValue`:
+An example of the two-closure sink:
 
 [source, swift]
 ----
 let examplePublisher = Just(5)
 
-let _ = examplePublisher.sink(receiveCompletion: { err in
+let cancellable = examplePublisher.sink(receiveCompletion: { err in
     print(".sink() received the completion", String(describing: err))
 }, receiveValue: { value in
     print(".sink() received \(String(describing: value))")
@@ -1891,13 +1914,16 @@ After a cancel is sent, no further values will be received by either closure in 
 
 [source,swift]
 ----
-let simplePublisher = PassthroughSubject<String, Error>()
+let simplePublisher = PassthroughSubject<String, Never>()
 let cancellablePipeline = simplePublisher.sink { data in
   // do what you need with the data...
 }
 
-cancellablePublisher.cancel() // this invalidates the pipeline, no further data will be received by the sink
+cancellablePublisher.cancel() // when invoked, this invalidates the pipeline
+// no further data will be received by the sink
 ----
+
+<<#reference-anycancellable>> is often used with the result of sink to convert the resulting type into AnyCancellable.
 
 [#reference-anycancellable]
 === AnyCancellable


### PR DESCRIPTION
various beta4 updates:

- make explicit references to subscribers to make sure the tests complete
- update subjects to sink from Error to Never since it got crankier about that
- swiftUI property name of color to foregroundcolor
- willChange and didChange to BindableObject protocol
- moving Empty to top level object (no longer on Publishers)
