### PR TITLE
beta5 updates

### DIFF
--- a/SwiftUI-Notes.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SwiftUI-Notes.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/tcldr/Entwine.git",
         "state": {
           "branch": "master",
-          "revision": "ce59b544794b5adafe751b9cda8dde495ea69dd0",
+          "revision": "d6b60871f28f37d9789007634bd1a34845c1b3cf",
           "version": null
         }
       }

--- a/UsingCombineTests/BreakpointPublisherTests.swift
+++ b/UsingCombineTests/BreakpointPublisherTests.swift
@@ -15,7 +15,12 @@ class BreakpointPublisherTests: XCTestCase {
         case invalidServerResponse
     }
 
-    func testBreakpointOnError() {
+    /* NOTE(heckj):
+     - these tests have all been prefixed with SKIP_ so they won't be run automatically with a whole
+       project validation. They explicitly drop breakpoints into the debugger, which is great when
+       you're actively debugging, but a complete PITA when you're trying to see a whole test sequence run.
+     */
+    func SKIP_testBreakpointOnError() {
 
         let publisher = PassthroughSubject<String?, Error>()
 
@@ -40,59 +45,59 @@ class BreakpointPublisherTests: XCTestCase {
         XCTAssertNotNil(cancellable)
     }
 
-        func testBreakpointOnSubscription() {
+    func SKIP_testBreakpointOnSubscription() {
 
-            let publisher = PassthroughSubject<String?, Error>()
+        let publisher = PassthroughSubject<String?, Error>()
 
-            // this sets up the chain of whatever it's going to do
-            let cancellable = publisher
-                .breakpoint(receiveSubscription: { subscription in
-                    return true // triggers breakpoint
-                }, receiveOutput: { value in
-                    return false
-                }, receiveCompletion: { completion in
-                    return false
-                })
-                .sink(
-                    receiveCompletion: { completion in
-                        print("sink captured the completion of \(String(describing: completion))")
-                    },
-                    receiveValue: { aValue in
-                        print("sink captured the result of \(String(describing: aValue))")
-                    }
-                )
-
-            publisher.send("DATA IN")
-            publisher.send(completion: .finished)
-            XCTAssertNotNil(cancellable)
-        }
-
-        func testBreakpointOnData() {
-
-            let publisher = PassthroughSubject<String?, Error>()
-            let cancellable = publisher
-                .breakpoint(receiveSubscription: { subscription in
-                    return false
-                }, receiveOutput: { value in
-                    return true // triggers breakpoint
-                }, receiveCompletion: { completion in
-                    return false
-                })
-                .map {
-                    $0 // does nothing, but can be convenient to hang a debugger breakpoint on to see the data
+        // this sets up the chain of whatever it's going to do
+        let cancellable = publisher
+            .breakpoint(receiveSubscription: { subscription in
+                return true // triggers breakpoint
+            }, receiveOutput: { value in
+                return false
+            }, receiveCompletion: { completion in
+                return false
+            })
+            .sink(
+                receiveCompletion: { completion in
+                    print("sink captured the completion of \(String(describing: completion))")
+                },
+                receiveValue: { aValue in
+                    print("sink captured the result of \(String(describing: aValue))")
                 }
-                .sink(
-                    // sink captures and terminates the pipeline of operators
-                    receiveCompletion: { completion in
-                        print("sink captured the completion of \(String(describing: completion))")
-                    },
-                    receiveValue: { aValue in
-                        print("sink captured the result of \(String(describing: aValue))")
-                    }
-                )
+            )
 
-            publisher.send("DATA IN")
-            publisher.send(completion: .finished)
-            XCTAssertNotNil(cancellable)
-        }
+        publisher.send("DATA IN")
+        publisher.send(completion: .finished)
+        XCTAssertNotNil(cancellable)
+    }
+
+    func SKIP_testBreakpointOnData() {
+
+        let publisher = PassthroughSubject<String?, Error>()
+        let cancellable = publisher
+            .breakpoint(receiveSubscription: { subscription in
+                return false
+            }, receiveOutput: { value in
+                return true // triggers breakpoint
+            }, receiveCompletion: { completion in
+                return false
+            })
+            .map {
+                $0 // does nothing, but can be convenient to hang a debugger breakpoint on to see the data
+            }
+            .sink(
+                // sink captures and terminates the pipeline of operators
+                receiveCompletion: { completion in
+                    print("sink captured the completion of \(String(describing: completion))")
+                },
+                receiveValue: { aValue in
+                    print("sink captured the result of \(String(describing: aValue))")
+                }
+            )
+
+        publisher.send("DATA IN")
+        publisher.send(completion: .finished)
+        XCTAssertNotNil(cancellable)
+    }
 }

--- a/UsingCombineTests/EncodeDecodeTests.swift
+++ b/UsingCombineTests/EncodeDecodeTests.swift
@@ -102,7 +102,7 @@ class EncodeDecodeTests: XCTestCase {
         XCTAssertNotNil(cancellable)
     }
 
-    func testSimpleEncodeError() {
+    func testSimpleEncodeNil() {
         // setup
         let dataProvider = PassthroughSubject<PostmanEchoTimeStampCheckResponse?, Never>()
 
@@ -117,15 +117,16 @@ class EncodeDecodeTests: XCTestCase {
                     break
                 case .failure(let anError):
                     print("received error: ", anError)
-                    XCTAssertEqual("The data couldn’t be written because it isn’t in the correct format.", anError.localizedDescription)
+                    XCTFail("shouldn't receive a finished with this sample")
                     break
                 }
             }, receiveValue: { data in
-                print(".sink() data received \(data)")
-                XCTFail("shouldn't receive any data with this sample")
+                let resultingString = String(data: data, encoding: .utf8)
+                XCTAssertEqual(resultingString, "null")
             })
 
         dataProvider.send(nil)
         XCTAssertNotNil(cancellable)
     }
+
 }

--- a/UsingCombineTests/PublisherTests.swift
+++ b/UsingCombineTests/PublisherTests.swift
@@ -11,9 +11,23 @@ import Combine
 
 class PublisherTests: XCTestCase {
 
-    struct HoldingStruct {
-        @Published var username: String = ""
-    }
+//    struct HoldingStruct {
+//        @Published var username: String = ""
+//    }
+
+    /* NOTE(heckj):
+     The above stanza (as of beta5) is now explicitly disallowed from the compiler, although it's
+     not reported very clearly in Xcode. The compiler error from the above lines:
+
+     <unknown>:0: error: 'wrappedValue' is unavailable: @Published is only available on properties of classes
+     Combine.Published:5:16: note: 'wrappedValue' has been explicitly marked unavailable here
+         public var wrappedValue: Value { get set }
+                    ^
+
+     Given that it's explicitly marked as unavailable, I'm presuming that the @Published annotation is
+     only to be used with properties on reference types (classes), and commenting out the tests that had
+     previously attempting to use it within a value type (struct).
+     */
 
     class HoldingClass {
         @Published var username: String = ""
@@ -28,18 +42,18 @@ class PublisherTests: XCTestCase {
         @objc dynamic var boolValue: Bool = false
     }
 
-    func testPublishedOnStruct() {
-        let expectation = XCTestExpectation(description: self.debugDescription)
-        let foo = HoldingStruct()
-
-        let cancellable = foo.$username
-            .sink { someString in
-                print("value of username updated to: >>\(someString)<<")
-                expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 5.0)
-        XCTAssertNotNil(cancellable)
-    }
+//    func testPublishedOnStruct() {
+//        let expectation = XCTestExpectation(description: self.debugDescription)
+//        let foo = HoldingStruct()
+//
+//        let cancellable = foo.$username
+//            .sink { someString in
+//                print("value of username updated to: >>\(someString)<<")
+//                expectation.fulfill()
+//        }
+//        wait(for: [expectation], timeout: 5.0)
+//        XCTAssertNotNil(cancellable)
+//    }
 
     func testPublishedOnClassInstance() {
         let expectation = XCTestExpectation(description: "async sink test")
@@ -53,31 +67,32 @@ class PublisherTests: XCTestCase {
         wait(for: [expectation], timeout: 5.0)
         XCTAssertNotNil(cancellable)
     }
-
-    func testPublishedOnStructWithChange() {
-        // NOTE(heckj) this test succeeded on beta 2, but fails on beta3 and beta4.
-        // documented to Apple as FB6608729
-        // beta2: ✅
-        // beta3: ❌
-        // beta4: ❌
-        let expectation = XCTestExpectation(description: self.debugDescription)
-        var foo = HoldingStruct()
-        let q = DispatchQueue(label: self.debugDescription)
-
-        let cancellable = foo.$username
-            .sink { someString in
-                print("value of username updated to: >>\(someString)<<")
-                if someString == "redfish" {
-                    expectation.fulfill()
-                }
-        }
-        q.async {
-            print("Updating to redfish on background queue")
-            foo.username = "redfish"
-        }
-        wait(for: [expectation], timeout: 5.0)
-        XCTAssertNotNil(cancellable)
-    }
+//
+//    func testPublishedOnStructWithChange() {
+//        // NOTE(heckj) this test succeeded on beta 2, but fails on beta3 and beta4.
+//        // documented to Apple as FB6608729
+//        // beta2: ✅
+//        // beta3: ❌
+//        // beta4: ❌
+//        // beta5: ❌ - compiler error
+//        let expectation = XCTestExpectation(description: self.debugDescription)
+//        var foo = HoldingStruct()
+//        let q = DispatchQueue(label: self.debugDescription)
+//
+//        let cancellable = foo.$username
+//            .sink { someString in
+//                print("value of username updated to: >>\(someString)<<")
+//                if someString == "redfish" {
+//                    expectation.fulfill()
+//                }
+//        }
+//        q.async {
+//            print("Updating to redfish on background queue")
+//            foo.username = "redfish"
+//        }
+//        wait(for: [expectation], timeout: 5.0)
+//        XCTAssertNotNil(cancellable)
+//    }
 
     func testPublishedOnClassWithChange() {
         let expectation = XCTestExpectation(description: self.debugDescription)

--- a/docs/reference.adoc
+++ b/docs/reference.adoc
@@ -147,10 +147,17 @@ Additional examples of how to arrange error handling for a continous publisher l
 
 [WARNING]
 ====
-As of the beta3 release of Combine with the updated operating systems, Published doesn't always trigger updates when a struct is the holding the @Published variable, but it works within a class instance.
-The unit tests at https://github.com/heckj/swiftui-notes/blob/master/UsingCombineTests/PublisherTests.swift[`UsingCombineTests/PublisherTests.swift`] illustrate this with the tests:
-* `testPublishedOnStructWithChange`
-* `testPublishedOnClassWithChange`
+Using `@Published` should only be done within reference types - that is, within classes.
+An early beta (2) allowed @Published wrapped within a struct.
+As of beta5, the compiler will no throw an error if this is attempted:
+
+[source]
+----
+<unknown>:0: error: 'wrappedValue' is unavailable: @Published is only available on properties of classes
+	     Combine.Published:5:16: note: 'wrappedValue' has been explicitly marked unavailable here
+	         public var wrappedValue: Value { get set }
+                        ^
+----
 ====
 
 [#reference-empty]


### PR DESCRIPTION
- passing nil to JSONEncoder no longer throws an error, instead correctly encodes to "null"
- adjusted breakpoint tests to be skipped by default, but left them in
- compiler now blows up on attempting to use @Published within a struct, so commented all that out and made notes in the tests to explain.