### PR TITLE
Fixes for capital letter typos

### DIFF
--- a/docs/aboutthisbook.adoc
+++ b/docs/aboutthisbook.adoc
@@ -61,7 +61,7 @@ Updates of the content will be made to the online version as development continu
 Larger updates and announcements will also be provided through https://gumroad.com/heckj[the author's profile at Gumroad].
 
 The contents of this book, as well as example code and unit tests referenced from the book, are link in an Xcode project (`SwiftUI-Notes.xcodeproj`), sourced from the GitHub repository https://github.com/heckj/swiftui-notes[heckj/swiftui-notes].
-The project includes unit tests illustrating the behavior of combine and example code showing Combine integration with UIKit and SwiftUI.
+The project includes unit tests illustrating the behavior of Combine and example code showing Combine integration with UIKit and SwiftUI.
 
 === Diagram Test
 

--- a/docs/coreconcepts.adoc
+++ b/docs/coreconcepts.adoc
@@ -4,7 +4,7 @@
 [#coreconcepts-publisher-subscriber]
 == Publisher, Subscriber
 
-Two key concepts, described in swift with protocols, are https://developer.apple.com/documentation/combine/publisher[*publisher*] and https://developer.apple.com/documentation/combine/subscriber[*subscriber*].
+Two key concepts, described in Swift with protocols, are https://developer.apple.com/documentation/combine/publisher[*publisher*] and https://developer.apple.com/documentation/combine/subscriber[*subscriber*].
 
 A publisher fundamentally provides data, when available, upon request.
 It is described with two associated types: one for Output and one for Failure.
@@ -72,7 +72,7 @@ This pattern will come in handy when you start constructing your own pipelines.
 When creating pipelines, you are often selecting operators to help you transform the types, to achieve your end goal.
 That end goal might be enabling or disabling a user interface element, or it might be retrieving some piece of data to be displayed.
 
-Many combine operators are specifically created to help with these transformations.
+Many Combine operators are specifically created to help with these transformations.
 Some operators require conformance to an input or failure type.
 Other operators may change either or both the failure and output types.
 For example, there are a number of operators that have a similar operator prefixed with `try`, which indicates they return an <Error> failure type.
@@ -400,7 +400,7 @@ Both `Assign` and `Sink` conform to the https://developer.apple.com/documentatio
 
 https://developer.apple.com/documentation/combine/subscribers/assign[`assign`] applies values passed down from the publisher to an object defined by a keypath.
 The keypath is set when the pipeline is created.
-An example of this in swift might look like:
+An example of this in Swift might look like:
 
 [source, swift]
 ----
@@ -410,7 +410,7 @@ An example of this in swift might look like:
 https://developer.apple.com/documentation/combine/subscribers/sink[`sink`] accepts a closure that receives any resulting values from the publisher.
 This allows the developer to terminate a pipeline with their own code.
 This subscriber is also extremely helpful when writing unit tests to validate either publishers or pipelines.
-An example of this in swift might look like:
+An example of this in Swift might look like:
 
 [source, swift]
 ----

--- a/docs/developingwith.adoc
+++ b/docs/developingwith.adoc
@@ -1,19 +1,19 @@
 [#developingwith]
 = Developing with Combine
 
-Developing with combine can take any of a number of different forms.
+Developing with Combine can take any of a number of different forms.
 
 A common starting point is composing pipelines, leveraging existing publishers, operators, and subcribers.
 A number of examples within this book highlight various patterns, many of which are aimed at providing declarative responses to user inputs within interfaces.
 
-You may also want to create APIs that integrate more easily into combine.
+You may also want to create APIs that integrate more easily into Combine.
 For example, creating a publisher that encapsulates a remote API, returning a single result or a series of results.
 
 Or you might be creating a subscriber to consume and process data over time.
 
 == Reasoning about pipelines
 
-When developing with combine, there are two broader patterns of how publishers are used that frequently recur: one-shot and continuous.
+When developing with Combine, there are two broader patterns of how publishers are used that frequently recur: one-shot and continuous.
 
 The first is what I'm calling a "one-shot" publisher or pipeline.
 These publishers are expected to create a single response (or perhaps no response) and then terminate normally.
@@ -22,7 +22,7 @@ The second is what I'm calling a "continuous" publisher.
 These publishers, or more often pipelines, are expected to be always active and providing the means to respond to ongoing events, either user initiated or another source.
 In this case, the lifetime of the pipeline is significant longer, and it is often not desirable to have such pipelines fail or terminate.
 
-When you are thinking about your development and how to use combine, it is often beneficial to think about pipelines as being one of these types, and mixing them together to achieve your goals.
+When you are thinking about your development and how to use Combine, it is often beneficial to think about pipelines as being one of these types, and mixing them together to achieve your goals.
 
 For example, the pattern <<patterns#patterns-continual-error-handling,Using flatMap with catch to handle errors>> in this book explicitly uses one-shot pipelines to support error handling on a continual pipeline.
 
@@ -33,12 +33,12 @@ In addition to how much data the pipeline or publisher will provide, and the exp
 Quite a number of pipelines are more about transforming data through various types, and handling possible error conditions in that processing.
 A good example of this is the use of returning a pipeline returning a list in the pattern <<patterns#patterns-update-interface-userinput,Declarative UI updates from user input>> to provide a means to represent an "empty" result, even though the list is never expected to have more than 1 item within it.
 
-Ultimately, using combine is grounded at both ends by the originating publisher, and how it is providing data (when it is available), and the subscriber ultimately consuming the data.
+Ultimately, using Combine is grounded at both ends by the originating publisher, and how it is providing data (when it is available), and the subscriber ultimately consuming the data.
 
 [#developingwith-types]
 == Swift types and exposing pipelines or subscribers
 
-When you compose pipelines within swift, the chaining of functions results in the type being exposed as nesting generic types.
+When you compose pipelines within Swift, the chaining of functions results in the type being exposed as nesting generic types.
 If you are creating a pipeline, and then wanting to provide that as an API to another part of your code, the type definition for the exposed property or function can be exceptionally complex.
 
 To illustrate the exposed type complexity, if you created a publisher from a PassthroughSubject such as:
@@ -68,7 +68,7 @@ Publishers.FlatMap<Publishers.Map<Publishers.Catch<Future<String, Error>, Just<S
 When you want to expose the code, all of that composition detail can be very distracting and make your code harder to use.
 
 To clean up that interface, and provide a nice API boundary, there are type erased classes which can wrap either publishers or subscribers.
-These explicitly hide the type complexity that builds up from chained functions in swift.
+These explicitly hide the type complexity that builds up from chained functions in Swift.
 
 The two classes used to expose simplified types for subscribers and publishers are:
 
@@ -133,16 +133,16 @@ Any operators following them will also be invoked on their scheduler, giving the
 
 If you want to be explicit about which thread context an operator or subsequent operation will run within, define it with the <<reference#reference-receive,receive>> operator.
 
-== Developing to use combine
+== Developing to use Combine
 
-There are two common paths to developing code leveraging combine.
+There are two common paths to developing code leveraging Combine.
 
 * First is simply leveraging synchronous (blocking) calls within a closure to one of the common operators.
 The two most prevelant operators leveraged for this are <<reference#reference-map,map>> and <<reference#reference-trymap,tryMap>>, for when your code needs to throw an Error.
 
 * Second is integrating your own code that is asynchronous, or APIs that provide a completion callback.
 If the code you are integrating is asynchronous, then you can't (quite) as easily use it within a closure.
-You need to wrap the asynchronous code with a structure that the combine operators can work with and invoke.
+You need to wrap the asynchronous code with a structure that the Combine operators can work with and invoke.
 In practice, this often implies creating a call that returns a publisher instance, and then using that within the pipeline.
 
 The <<reference#reference-future,Future>> publisher was specifically created to support this kind of integration, and the pattern <<patterns#patterns-future,Wrapping an asynchronous call with a Future to create a one-shot publisher>> shows an example.

--- a/docs/introduction.adoc
+++ b/docs/introduction.adoc
@@ -41,7 +41,7 @@ Or more generally for creating pipelines that process data from external sources
 
 == Combine specifics
 
-Applying these concepts to a strongly typed language like swift is part of what Apple has created in Combine.
+Applying these concepts to a strongly typed language like Swift is part of what Apple has created in Combine.
 Combine embeds the concept of back-pressure, which allows the subscriber to control how much information it gets at once and needs to process.
 In addition, it supports efficient operation with the notion of streams that are cancellable and driven primarily by the subscriber.
 

--- a/docs/pattern-cascading-update-interface.adoc
+++ b/docs/pattern-cascading-update-interface.adoc
@@ -39,7 +39,7 @@ __See also__::
 
 __Code and explanation__::
 
-The example provided expands on a publisher updating from <<patterns#patterns-update-interface-userinput,Declarative UI updates from user input>>, adding additional combine pipelines to update multiple UI elements.
+The example provided expands on a publisher updating from <<patterns#patterns-update-interface-userinput,Declarative UI updates from user input>>, adding additional Combine pipelines to update multiple UI elements.
 
 The general pattern of this view starts with a textfield that accepts user input:
 
@@ -55,7 +55,7 @@ The empty list is useful to return because when a username is provided that does
 To do this, we need the pipelines to fully resolve to some value, so that further pipelines are triggered and the relevant UI interfaces updated.
 
 The subscribers (created with <<reference#reference-assign,assign>> and <<reference#reference-sink,sink>>) are stored as AnyCancellable variables on the ViewController instance.
-Because they are defined on the class instance, the swift compiler creates initializers and deinitializers, which will cancel and clean up the publishers when the class is torn down.
+Because they are defined on the class instance, the Swift compiler creates initializers and deinitializers, which will cancel and clean up the publishers when the class is torn down.
 
 [NOTE]
 ====

--- a/docs/pattern-delegate-publisher-subject.adoc
+++ b/docs/pattern-delegate-publisher-subject.adoc
@@ -3,7 +3,7 @@
 
 __Goal__::
 
-* To use one of the Apple delegate APIs to provide values to be used in a combine pipeline.
+* To use one of the Apple delegate APIs to provide values to be used in a Combine pipeline.
 
 __References__::
 

--- a/docs/pattern-future.adoc
+++ b/docs/pattern-future.adoc
@@ -3,7 +3,7 @@
 
 __Goal__::
 
-* Using Future to turn an an asynchronous call into publisher to use the result in a combine pipeline.
+* Using Future to turn an asynchronous call into publisher to use the result in a Combine pipeline.
 
 __References__::
 

--- a/docs/pattern-notificationcenter.adoc
+++ b/docs/pattern-notificationcenter.adoc
@@ -16,7 +16,7 @@ __See also__::
 __Code and explanation__::
 
 A large number of frameworks and user interface components provide information about their state and interactions via Notifications from NotificationCenter.
-Apple's documentation includes an article on https://developer.apple.com/documentation/combine/receiving_and_handling_events_with_combine[receiving and handling events with combine] specifically referencing NotificationCenter.
+Apple's documentation includes an article on https://developer.apple.com/documentation/combine/receiving_and_handling_events_with_combine[receiving and handling events with Combine] specifically referencing NotificationCenter.
 
 https://developer.apple.com/documentation/foundation/notification[Notifications] flowing through https://developer.apple.com/documentation/foundation/notificationcenter[NotificationCenter] provide a common, central location for events within your application.
 
@@ -47,7 +47,7 @@ NotificationCenter.default.post(note)
 ====
 While commonly in use within AppKit and MacOS applications, not all developers are comfortable with heavily using NotificationCenter.
 Originating within the more dynamic Objective-C runtime, Notifications leverage Any and optional types quite extensively.
-Using them within swift code, or a pipeline, implies that the pipeline will have to provide the type assertions and deal with any possible errors related to data that may or may not be expected.
+Using them within Swift code, or a pipeline, implies that the pipeline will have to provide the type assertions and deal with any possible errors related to data that may or may not be expected.
 ====
 
 When creating the NotificationCenter publisher, you provide the name of the notification for which you want to receive, and optionally an object reference to filter to specific types of objects.

--- a/docs/pattern-sequencing-operations.adoc
+++ b/docs/pattern-sequencing-operations.adoc
@@ -19,7 +19,7 @@ __See also__::
 
 __Code and explanation__::
 
-Any asynchronous (or synchronous) set of tasks that need to happen in a specific order can also be coordinated using a combine pipeline.
+Any asynchronous (or synchronous) set of tasks that need to happen in a specific order can also be coordinated using a Combine pipeline.
 By using <<reference#reference-future,Future>> operator, the very act of completing an asynchronous call can be captured, and sequencing operators provides the structure of that coordination.
 
 For example, by wrapping an asynchronous API calls with the <<reference#reference-future,Future>> publisher and then chaining them together with the <<reference#reference-flatmap,flatMap>> operator, you invoke the wrapped asynchronous API calls in the order of the pipeline.

--- a/docs/pattern-test-entwine.adoc
+++ b/docs/pattern-test-entwine.adoc
@@ -30,7 +30,7 @@ An example of this from the EntwineTest project is included:
 import XCTest
 import EntwineTest
 // library loaded from https://github.com/tcldr/Entwine/blob/master/Assets/EntwineTest/README.md
-// as a swift package https://github.com/tcldr/Entwine.git : 0.6.0, Next Major Version
+// as a Swift package https://github.com/tcldr/Entwine.git : 0.6.0, Next Major Version
 
 class EntwineTestExampleTests: XCTestCase {
 

--- a/docs/pattern-test-pipeline-expectation.adoc
+++ b/docs/pattern-test-pipeline-expectation.adoc
@@ -26,7 +26,7 @@ When you are testing a publisher, or something that creates a publisher, you may
 Combine, being driven by its subscribers, can set up a sync that initiates the data flow.
 You can use an https://developer.apple.com/documentation/xctest/xctestexpectation[XCTestExpectation] to wait an explicit amount of time for the test to run to completion.
 
-A general pattern for using this with combine includes:
+A general pattern for using this with Combine includes:
 
 . set up the expectation within the test
 . establish the code you are going to test

--- a/docs/pattern-test-subscriber-scheduled.adoc
+++ b/docs/pattern-test-subscriber-scheduled.adoc
@@ -67,7 +67,7 @@ This really only shows when debugging test failures, and is convenient as a remi
 A definite downside to this technique is that it forces the test to take a minimum amount of time matching the maximum queue delay in the test.
 
 Another option is a 3rd party library named EntwineTest, which was inspired by the RxTest library.
-EntwineTest is part of Entwine, a swift library that expands on Combine with some helpers.
+EntwineTest is part of Entwine, a Swift library that expands on Combine with some helpers.
 The library can be found on Github at https://github.com/tcldr/Entwine.git, available under the MIT license.
 
 One of the key elements included in EnwtineTest is a virtual time scheduler, as well as additional classes that schedule (TestablePublisher) and collect and record (TestableSubscriber) the timing of results while using this scheduler.

--- a/docs/pattern-test-subscriber-subject.adoc
+++ b/docs/pattern-test-subscriber-subject.adoc
@@ -122,7 +122,7 @@ Additionally, we have an error definition defined here because it's not coming f
 <3> The subscriber setup under test (in this case, a standard <<reference#reference-sink,sink>>).
 We have code paths that trigger on receiving data and completions.
 <4> Within the completion path, we switch on the type of completion, adding an assertion that will fail the test if a finish is called, as we expect to only generate a `.failure` completion.
-<5> I find testing error equality in swift to be awkward, but if the error is code you are controller, you can sometimes use the `localizedDescription` as a convenient way to test the type of error received.
+<5> I find testing error equality in Swift to be awkward, but if the error is code you are controller, you can sometimes use the `localizedDescription` as a convenient way to test the type of error received.
 <6> The `receiveValue` closure is more complex in how it asserts its values.
 Since we are receiving multiple values in the process of this test, we have some additional logic to simply check that the values are within the set that we send.
 Like the completion handler, We also increment test specific variables that we will assert on later to validate state and order of operation.

--- a/docs/pattern-update-interface-userinput.adoc
+++ b/docs/pattern-update-interface-userinput.adoc
@@ -90,7 +90,7 @@ class ViewController: UIViewController {
 
 <1> The UITextField is the interface element which is driving the updates from user interaction.
 <2> We defined a <<reference#reference-published,Published>> property to both hold the updates.
-Because its a Published property, it provides a publisher reference that we can use to attach additional combine pipelines to update other variables or elements of the interface.
+Because its a Published property, it provides a publisher reference that we can use to attach additional Combine pipelines to update other variables or elements of the interface.
 <3> We set the variable `username` from within an IBAction, which in turn triggers a data flow if the publisher `$username` has any subscribers.
 <4> We in turn set up a subscriber on the publisher `$username` that does further actions. In this case the overall flow retrives an instance of a GithubAPIUser from Github's REST API.
 <5> The <<reference#reference-throttle,throttle>> is there to keep from triggering a network request on ever request.

--- a/docs/patterns.adoc
+++ b/docs/patterns.adoc
@@ -67,7 +67,7 @@ include::pattern-bindableobject.adoc[]
 [#patterns-testing-and-debugging]
 == Testing and Debugging
 
-The Publisher/Subscriber interface in combine is beautifully suited to be an easily testable interface.
+The Publisher/Subscriber interface in Combine is beautifully suited to be an easily testable interface.
 
 With the composability of Combine, you can use this to your advantage, creating APIs that present, or consume, code that conforms to https://developer.apple.com/documentation/combine/publisher[Publisher].
 

--- a/docs/reference.adoc
+++ b/docs/reference.adoc
@@ -109,7 +109,7 @@ __Usage__::
 
 __Details__::
 
-Published is part of combine, but allows you to wrap a property, enabling you to get a publisher that triggers data updates whenever the property is changed.
+Published is part of Combine, but allows you to wrap a property, enabling you to get a publisher that triggers data updates whenever the property is changed.
 The publisher's output type is inferred from the type of the property, and the error type of the provided publisher is <Never>.
 
 A smaller examples of how it can be used:
@@ -135,7 +135,7 @@ The publisher for the property is available at the same scope, and with the same
 <2> The publisher is accessible as `$username`, of type `Published<String>.publisher`.
 <3> A Published property can have more than one subscriber pipeline triggering from it.
 <4> If you're publishing your own type, you may find it convenient to publish an array of that type as the property, even if you only reference a single value.
-This allows you represent an "Empty" result that is still a concrete result within combine pipelines, as <<reference#reference-assign,assign>> and <<reference#reference-sink,sink>> subscribers will only trigger updates on non-nil values.
+This allows you represent an "Empty" result that is still a concrete result within Combine pipelines, as <<reference#reference-assign,assign>> and <<reference#reference-sink,sink>> subscribers will only trigger updates on non-nil values.
 
 If the publisher generated from `@Published` receives a cancellation from any subscriber, it is expected to, and will cease, reporting property changes.
 Because of this expectation, it is common to arrange pipelines from these publishers that have an error type of `<Never>` and do all error handling within the pipelines.
@@ -680,7 +680,7 @@ A diagram version of this pipeline construct might be:
 publisher -> flatMap -> ( +                           +  ) -> subscriber
 ----
 
-In swift, this looks like:
+In Swift, this looks like:
 
 [source, swift]
 ----
@@ -1983,7 +1983,7 @@ That is - don't create the queue with `attributes: .concurrent`.
 [#reference-erasetoanypublisher]
 ==== eraseToAnyPublisher
 
-** when you chain operators together in swift, the object's type signature accumulates all the various types, and it gets ugly pretty quickly.
+** when you chain operators together in Swift, the object's type signature accumulates all the various types, and it gets ugly pretty quickly.
 ** eraseToAnyPublisher takes the signature and "erases" the type back to the common type of AnyPublisher
 ** this provides a cleaner type for external declarations (framework was created prior to Swift 5's opaque types)
 ** `.eraseToAnyPublisher()`


### PR DESCRIPTION
swift -> Swift
combine -> Combine
"an an" -> "an"