### PR TITLE
Title case object types

### DIFF
--- a/SwiftUI-NotesTests/CombinePatternTests.swift
+++ b/SwiftUI-NotesTests/CombinePatternTests.swift
@@ -11,7 +11,7 @@ import Combine
 
 class CombinePatternTests: XCTestCase {
 
-    enum testFailureCondition: Error {
+    enum TestFailureCondition: Error {
         case invalidServerResponse
     }
 
@@ -34,12 +34,12 @@ class CombinePatternTests: XCTestCase {
                 // this print adds into the console output:
                 //        .sink() received firstStringValue
                 //        .sink() received secondStringValue
-                //        .sink() caught the failure failure(SwiftUI_NotesTests.CombinePatternTests.testFailureCondition.invalidServerResponse)
+                //        .sink() caught the failure failure(SwiftUI_NotesTests.CombinePatternTests.TestFailureCondition.invalidServerResponse)
             })
 
         simplePublisher.send("firstStringValue")
         simplePublisher.send("secondStringValue")
-        simplePublisher.send(completion: Subscribers.Completion.failure(testFailureCondition.invalidServerResponse))
+        simplePublisher.send(completion: Subscribers.Completion.failure(TestFailureCondition.invalidServerResponse))
 
         // this data will never be seen by anything in the pipeline above because we've already sent a completion
         simplePublisher.send(completion: Subscribers.Completion.finished)
@@ -52,7 +52,7 @@ class CombinePatternTests: XCTestCase {
 //        receive value: (secondStringValue)
 //        .sink() received secondStringValue
 //        receive error: (invalidServerResponse)
-//        .sink() caught the failure failure(SwiftUI_NotesTests.CombinePatternTests.testFailureCondition.invalidServerResponse)
+//        .sink() caught the failure failure(SwiftUI_NotesTests.CombinePatternTests.TestFailureCondition.invalidServerResponse)
 
     }
 
@@ -71,7 +71,7 @@ class CombinePatternTests: XCTestCase {
         simplePublisher.send("twoValue")
 
         // uncomment this next line to see the failure mode:
-        // simplePublisher.send(completion: Subscribers.Completion.failure(testFailureCondition.invalidServerResponse))
+        // simplePublisher.send(completion: Subscribers.Completion.failure(TestFailureCondition.invalidServerResponse))
         simplePublisher.send(completion: .finished)
     }
 
@@ -91,7 +91,7 @@ class CombinePatternTests: XCTestCase {
 
         simplePublisher.send("oneValue")
         simplePublisher.send("twoValue")
-        simplePublisher.send(completion: Subscribers.Completion.failure(testFailureCondition.invalidServerResponse))
+        simplePublisher.send(completion: Subscribers.Completion.failure(TestFailureCondition.invalidServerResponse))
         simplePublisher.send("redValue")
         simplePublisher.send("blueValue")
         simplePublisher.send(completion: .finished)

--- a/SwiftUI-NotesTests/SwiftUI_CombineTests.swift
+++ b/SwiftUI-NotesTests/SwiftUI_CombineTests.swift
@@ -138,16 +138,16 @@ class SwiftUI_CombineTests: XCTestCase {
      */
 
     func testAnyFuture_FailingAFuture() {
-        enum sampleError: Error {
+        enum SampleError: Error {
             case exampleError
             case aDifferentError
         }
 
         // A generic Future that always returns a Failure
-        let badPlace = Future<String, sampleError> { promise in
+        let badPlace = Future<String, SampleError> { promise in
             // promise is Result<Any, Error> and this is expect to return Void
             // you generally call promise with .success() or .failure() enclosing relevant information (or results)
-            promise(.failure(sampleError.exampleError))
+            promise(.failure(SampleError.exampleError))
         }
 
         // NOTE(heckj) I'm not entirely clear on how you can/should check failure path of a result chain
@@ -172,11 +172,11 @@ class SwiftUI_CombineTests: XCTestCase {
 
         /*
         let _ = badPlace
-            .mapError({ someError -> sampleError in // -> sampleError is because the compiler can't infer the type...
+            .mapError({ someError -> SampleError in // -> SampleError is because the compiler can't infer the type...
                 XCTAssertNil(someError) // by itself this errors with: Cannot convert value of type '()' to closure result type '_'
-                // XCTAssertEqual(sampleError.exampleError, someError)
+                // XCTAssertEqual(SampleError.exampleError, someError)
                 // This doesn't work, compiler error: "Protocol type 'Error' cannot conform to 'Equatable' because only concrete types can conform to protocols"
-                return sampleError.aDifferentError
+                return SampleError.aDifferentError
             })
          */
 

--- a/UsingCombineTests/BreakpointPublisherTests.swift
+++ b/UsingCombineTests/BreakpointPublisherTests.swift
@@ -11,7 +11,7 @@ import Combine
 
 class BreakpointPublisherTests: XCTestCase {
 
-    enum testFailureCondition: Error {
+    enum TestFailureCondition: Error {
         case invalidServerResponse
     }
 
@@ -27,7 +27,7 @@ class BreakpointPublisherTests: XCTestCase {
         // this sets up the chain of whatever it's going to do
         let cancellable = publisher
             .tryMap { stringValue in
-                throw testFailureCondition.invalidServerResponse
+                throw TestFailureCondition.invalidServerResponse
             }
             .breakpointOnError()
             .sink(

--- a/UsingCombineTests/DataTaskPublisherTests.swift
+++ b/UsingCombineTests/DataTaskPublisherTests.swift
@@ -15,7 +15,7 @@ class DataTaskPublisherTests: XCTestCase {
     var mockURL: URL?
     var myBackgroundQueue: DispatchQueue?
 
-    enum testFailureCondition: Error {
+    enum TestFailureCondition: Error {
         case invalidServerResponse
     }
 
@@ -141,7 +141,7 @@ class DataTaskPublisherTests: XCTestCase {
             .tryMap { data, response -> Data in
                 guard let httpResponse = response as? HTTPURLResponse,
                     httpResponse.statusCode == 200 else {
-                        throw testFailureCondition.invalidServerResponse
+                        throw TestFailureCondition.invalidServerResponse
                 }
                 return data
             }
@@ -195,7 +195,7 @@ class DataTaskPublisherTests: XCTestCase {
             .tryMap { data, response -> Data in
                 guard let httpResponse = response as? HTTPURLResponse,
                     httpResponse.statusCode == 200 else {
-                        throw testFailureCondition.invalidServerResponse
+                        throw TestFailureCondition.invalidServerResponse
                 }
                 return data
             }
@@ -255,7 +255,7 @@ class DataTaskPublisherTests: XCTestCase {
             .tryMap { data, response -> Data in
                 guard let httpResponse = response as? HTTPURLResponse,
                     httpResponse.statusCode == 200 else {
-                        throw testFailureCondition.invalidServerResponse
+                        throw TestFailureCondition.invalidServerResponse
                 }
                 return data
             }
@@ -294,7 +294,7 @@ class DataTaskPublisherTests: XCTestCase {
                 .tryMap { data, response -> Data in
                         guard let httpResponse = response as? HTTPURLResponse,
                             httpResponse.statusCode == 200 else {
-                                throw testFailureCondition.invalidServerResponse
+                                throw TestFailureCondition.invalidServerResponse
                         }
                         return data
                 }

--- a/UsingCombineTests/FailedPublisherTests.swift
+++ b/UsingCombineTests/FailedPublisherTests.swift
@@ -11,14 +11,14 @@ import Combine
 
 class FailedPublisherTests: XCTestCase {
 
-    enum testFailureCondition: Error {
+    enum TestFailureCondition: Error {
         case exampleFailure
     }
 
     func testFailPublisher() {
         let expectation = XCTestExpectation(description: self.debugDescription)
 
-        let cancellable = Fail<String, Error>(error: testFailureCondition.exampleFailure)
+        let cancellable = Fail<String, Error>(error: TestFailureCondition.exampleFailure)
             .sink(receiveCompletion: { completion in
                 print(".sink() received the completion", String(describing: completion))
                 switch completion {
@@ -42,7 +42,7 @@ class FailedPublisherTests: XCTestCase {
     func testFailPublisherAltInitializer() {
         let expectation = XCTestExpectation(description: self.debugDescription)
 
-        let cancellable = Fail(outputType: String.self, failure: testFailureCondition.exampleFailure)
+        let cancellable = Fail(outputType: String.self, failure: TestFailureCondition.exampleFailure)
             .sink(receiveCompletion: { completion in
                 print(".sink() received the completion", String(describing: completion))
                 switch completion {

--- a/UsingCombineTests/FuturePublisherTests.swift
+++ b/UsingCombineTests/FuturePublisherTests.swift
@@ -11,7 +11,7 @@ import Combine
 
 class FuturePublisherTests: XCTestCase {
 
-    enum testFailureCondition: Error {
+    enum TestFailureCondition: Error {
         case anErrorExample
     }
 
@@ -20,7 +20,7 @@ class FuturePublisherTests: XCTestCase {
         DispatchQueue.global(qos: .background).async {
             sleep(.random(in: 1...3))
             if sabotage {
-                completionBlock(false, testFailureCondition.anErrorExample)
+                completionBlock(false, TestFailureCondition.anErrorExample)
             }
             completionBlock(true, nil)
         }

--- a/UsingCombineTests/MergingPipelineTests.swift
+++ b/UsingCombineTests/MergingPipelineTests.swift
@@ -115,7 +115,7 @@ class MergingPipelineTests: XCTestCase {
 
     func testCombineLatestWithFailure() {
         // setup
-        enum testFailureCondition: Error {
+        enum TestFailureCondition: Error {
             case example
         }
 
@@ -126,7 +126,7 @@ class MergingPipelineTests: XCTestCase {
             (100, .input("a")),
             (200, .input("b")),
             (350, .input("c")),
-            (400, .completion(.failure(testFailureCondition.example)))
+            (400, .completion(.failure(TestFailureCondition.example)))
         ])
         let testablePublisher2: TestablePublisher<Int, Error> = testScheduler.createRelativeTestablePublisher([
             (100, .input(1)),
@@ -153,7 +153,7 @@ class MergingPipelineTests: XCTestCase {
 //             (450, .input(("b", 2))),
 //             (500, .input(("b", 3))),
 //             (550, .input(("c", 3))),
-//             (600, .completion(failure(UsingCombineTests.MergingPipelineTests.(unknown context at $108734d68).(unknown context at $108734dd8).testFailureCondition.example)))
+//             (600, .completion(failure(UsingCombineTests.MergingPipelineTests.(unknown context at $108734d68).(unknown context at $108734dd8).TestFailureCondition.example)))
 //        terminating one of the streams completing with .failure terminates all of the pipeline
 //            ])
 

--- a/UsingCombineTests/NotificationCenterPublisherTests.swift
+++ b/UsingCombineTests/NotificationCenterPublisherTests.swift
@@ -12,11 +12,11 @@ extension Notification.Name {
     static let myExampleNotification = Notification.Name("an-example-notification")
 }
 
-class exampleClass {
+class ExampleClass {
     var aProperty: String = ""
 }
 
-struct exampleStruct {
+struct ExampleStruct {
     var aProperty: String = ""
 }
 
@@ -43,7 +43,7 @@ class NotificationCenterPublisherTests: XCTestCase {
 
     func testNotificationCenterPublisherWithRefObject() {
         let expectation = XCTestExpectation(description: self.debugDescription)
-        let refInstance = exampleClass()
+        let refInstance = ExampleClass()
         refInstance.aProperty = "hello"
 
         let cancellable = NotificationCenter.default.publisher(for: .myExampleNotification, object: refInstance)
@@ -51,7 +51,7 @@ class NotificationCenterPublisherTests: XCTestCase {
                 print("passed through: ", receivedNotification)
                 XCTAssertNil(receivedNotification.userInfo)
                 XCTAssertNotNil(receivedNotification.object)
-                XCTAssertEqual(receivedNotification.description, "name = an-example-notification, object = Optional(UsingCombineTests.exampleClass), userInfo = nil")
+                XCTAssertEqual(receivedNotification.description, "name = an-example-notification, object = Optional(UsingCombineTests.ExampleClass), userInfo = nil")
                 expectation.fulfill()
             }
 
@@ -63,7 +63,7 @@ class NotificationCenterPublisherTests: XCTestCase {
 
     func testNotificationCenterPublisherWithValueObject() {
         let expectation = XCTestExpectation(description: self.debugDescription)
-        let valInstance = exampleStruct(aProperty: "hello")
+        let valInstance = ExampleStruct(aProperty: "hello")
 
         let cancellable = NotificationCenter.default.publisher(for: .myExampleNotification, object: nil)
             // can't use the object parameter to filter on a value reference, only class references, but
@@ -74,7 +74,7 @@ class NotificationCenterPublisherTests: XCTestCase {
 
                 XCTAssertNil(receivedNotification.userInfo)
                 XCTAssertNotNil(receivedNotification.object)
-                XCTAssertEqual(receivedNotification.description, "name = an-example-notification, object = Optional(UsingCombineTests.exampleStruct(aProperty: \"hello\")), userInfo = nil")
+                XCTAssertEqual(receivedNotification.description, "name = an-example-notification, object = Optional(UsingCombineTests.ExampleStruct(aProperty: \"hello\")), userInfo = nil")
                 expectation.fulfill()
             }
 

--- a/UsingCombineTests/PublisherTests.swift
+++ b/UsingCombineTests/PublisherTests.swift
@@ -33,7 +33,7 @@ class PublisherTests: XCTestCase {
         @Published var username: String = ""
     }
 
-    enum failureCondition: Error {
+    enum FailureCondition: Error {
         case selfDestruct
     }
 
@@ -162,7 +162,7 @@ class PublisherTests: XCTestCase {
             .print(self.debugDescription)
             .tryMap({ myValue -> String in
                 if (myValue == "boom") {
-                    throw failureCondition.selfDestruct
+                    throw FailureCondition.selfDestruct
                 }
                 return "mappedValue"
             })

--- a/UsingCombineTests/RetryPublisherTests.swift
+++ b/UsingCombineTests/RetryPublisherTests.swift
@@ -11,7 +11,7 @@ import Combine
 
 class RetryPublisherTests: XCTestCase {
 
-    enum testFailureCondition: Error {
+    enum TestFailureCondition: Error {
         case invalidServerResponse
     }
 
@@ -38,7 +38,7 @@ class RetryPublisherTests: XCTestCase {
         simpleControlledPublisher.send(twoFish)
 
         // with an error response, this prints two results and hangs...
-        simpleControlledPublisher.send(completion: Subscribers.Completion.failure(testFailureCondition.invalidServerResponse))
+        simpleControlledPublisher.send(completion: Subscribers.Completion.failure(TestFailureCondition.invalidServerResponse))
 
         // with a completion, this prints two results and ends
         //simpleControlledPublisher.send(completion: .finished)
@@ -67,7 +67,7 @@ class RetryPublisherTests: XCTestCase {
 
         simpleControlledPublisher.send(oneFish)
         // with an error response, this prints two results and hangs...
-        simpleControlledPublisher.send(completion: Subscribers.Completion.failure(testFailureCondition.invalidServerResponse))
+        simpleControlledPublisher.send(completion: Subscribers.Completion.failure(TestFailureCondition.invalidServerResponse))
         XCTAssertNotNil(cancellable)
         // with a completion, this prints two results and ends
         //simpleControlledPublisher.send(completion: .finished)
@@ -118,7 +118,7 @@ class RetryPublisherTests: XCTestCase {
     func testRetryWithOneShotFailPublisher() {
         // setup
 
-        let cancellable = Fail(outputType: String.self, failure: testFailureCondition.invalidServerResponse)
+        let cancellable = Fail(outputType: String.self, failure: TestFailureCondition.invalidServerResponse)
             .print("(1)>")
             .retry(3)
             .print("(2)>")
@@ -139,7 +139,7 @@ class RetryPublisherTests: XCTestCase {
         //        (1)>: receive subscription: (Empty)
         //        (1)>: receive error: (invalidServerResponse)
         //        (2)>: receive error: (invalidServerResponse)
-        //        ** .sink() received the completion: failure(SwiftUI_NotesTests.CombinePatternTests.testFailureCondition.invalidServerResponse)
+        //        ** .sink() received the completion: failure(SwiftUI_NotesTests.CombinePatternTests.TestFailureCondition.invalidServerResponse)
         //        (2)>: receive subscription: (Retry)
         //        (2)>: request unlimited
 

--- a/UsingCombineTests/SinkSubscriberTests.swift
+++ b/UsingCombineTests/SinkSubscriberTests.swift
@@ -46,7 +46,7 @@ class SinkSubscriberTests: XCTestCase {
     func testSinkReceiveDataThenError() {
         // setup - preconditions
         let expectedValues = ["firstStringValue", "secondStringValue"]
-        enum testFailureCondition: Error {
+        enum TestFailureCondition: Error {
             case anErrorExample
         }
         var countValuesReceived = 0
@@ -67,7 +67,7 @@ class SinkSubscriberTests: XCTestCase {
                     // do what you want with the error details, presenting, logging, or hiding as appropriate
                     print("received the error: ", anError)
                     XCTAssertEqual(anError.localizedDescription,
-                                   testFailureCondition.anErrorExample.localizedDescription)
+                                   TestFailureCondition.anErrorExample.localizedDescription)
                     break
                 }
             }, receiveValue: { someValue in
@@ -93,7 +93,7 @@ class SinkSubscriberTests: XCTestCase {
         XCTAssertEqual(countValuesReceived, 2)
         XCTAssertEqual(countCompletionsReceived, 0)
 
-        simplePublisher.send(completion: Subscribers.Completion.failure(testFailureCondition.anErrorExample))
+        simplePublisher.send(completion: Subscribers.Completion.failure(TestFailureCondition.anErrorExample))
         XCTAssertEqual(countValuesReceived, 2)
         XCTAssertEqual(countCompletionsReceived, 1)
 

--- a/UsingCombineTests/SwitchAndFlatMapPublisherTests.swift
+++ b/UsingCombineTests/SwitchAndFlatMapPublisherTests.swift
@@ -16,7 +16,7 @@ class SwitchAndFlatMapPublisherTests: XCTestCase {
         var ip: String
     }
 
-    enum testFailureCondition: Error {
+    enum TestFailureCondition: Error {
         case invalidServerResponse
     }
 

--- a/docs/pattern-continual-error-handling.adoc
+++ b/docs/pattern-continual-error-handling.adoc
@@ -37,7 +37,7 @@ let remoteDataPublisher = Just(self.testURL!) <1>
         .tryMap { data, response -> Data in <4>
             guard let httpResponse = response as? HTTPURLResponse,
                 httpResponse.statusCode == 200 else {
-                    throw testFailureCondition.invalidServerResponse
+                    throw TestFailureCondition.invalidServerResponse
             }
             return data
         }

--- a/docs/pattern-datataskpublisher-trymap.adoc
+++ b/docs/pattern-datataskpublisher-trymap.adoc
@@ -35,7 +35,7 @@ let myURL = URL(string: "https://postman-echo.com/time/valid?timestamp=2016-10-1
 fileprivate struct PostmanEchoTimeStampCheckResponse: Decodable, Hashable {
     let valid: Bool
 }
-enum testFailureCondition: Error {
+enum TestFailureCondition: Error {
     case invalidServerResponse
 }
 
@@ -44,7 +44,7 @@ let remoteDataPublisher = URLSession.shared.dataTaskPublisher(for: myURL!)
     .tryMap { data, response -> Data in <1>
                 guard let httpResponse = response as? HTTPURLResponse, <2>
                     httpResponse.statusCode == 200 else { <3>
-                        throw testFailureCondition.invalidServerResponse <4>
+                        throw TestFailureCondition.invalidServerResponse <4>
                 }
                 return data <5>
     }

--- a/docs/pattern-debugging-pipelines-print.adoc
+++ b/docs/pattern-debugging-pipelines-print.adoc
@@ -122,7 +122,7 @@ An example of doing this, leveraging the prefix to show the <<reference#referenc
 func testRetryWithOneShotFailPublisher() {
     // setup
 
-    let _ = Fail(outputType: String.self, failure: testFailureCondition.invalidServerResponse)
+    let _ = Fail(outputType: String.self, failure: TestFailureCondition.invalidServerResponse)
         .print("(1)>") <1>
         .retry(3)
         .print("(2)>") <2>
@@ -154,7 +154,7 @@ Test Case '-[UsingCombineTests.RetryPublisherTests testRetryWithOneShotFailPubli
 (1)>: receive subscription: (Empty)
 (1)>: receive error: (invalidServerResponse)
 (2)>: receive error: (invalidServerResponse) <2>
- ** .sink() received the completion: failure(UsingCombineTests.RetryPublisherTests.testFailureCondition.invalidServerResponse)
+ ** .sink() received the completion: failure(UsingCombineTests.RetryPublisherTests.TestFailureCondition.invalidServerResponse)
 (2)>: receive subscription: (Retry)
 (2)>: request unlimited
 (2)>: receive cancel

--- a/docs/pattern-retry.adoc
+++ b/docs/pattern-retry.adoc
@@ -37,7 +37,7 @@ let remoteDataPublisher = urlSession.dataTaskPublisher(for: self.mockURL!)
     .tryMap { data, response -> Data in <3>
         guard let httpResponse = response as? HTTPURLResponse,
             httpResponse.statusCode == 200 else {
-                throw testFailureCondition.invalidServerResponse
+                throw TestFailureCondition.invalidServerResponse
         }
         return data
     }

--- a/docs/pattern-test-subscriber-subject.adoc
+++ b/docs/pattern-test-subscriber-subject.adoc
@@ -56,7 +56,7 @@ func testSinkReceiveDataThenError() {
 
     // setup - preconditions <1>
     let expectedValues = ["firstStringValue", "secondStringValue"]
-    enum testFailureCondition: Error {
+    enum TestFailureCondition: Error {
         case anErrorExample
     }
     var countValuesReceived = 0
@@ -80,7 +80,7 @@ func testSinkReceiveDataThenError() {
                 // logging, or hiding as appropriate
                 print("received the error: ", anError)
                 XCTAssertEqual(anError.localizedDescription,
-                               testFailureCondition.anErrorExample.localizedDescription) <5>
+                               TestFailureCondition.anErrorExample.localizedDescription) <5>
                 break
             }
         }, receiveValue: { someValue in <6>
@@ -105,7 +105,7 @@ func testSinkReceiveDataThenError() {
     XCTAssertEqual(countValuesReceived, 2)
     XCTAssertEqual(countCompletionsReceived, 0)
 
-    simplePublisher.send(completion: Subscribers.Completion.failure(testFailureCondition.anErrorExample))  <9>
+    simplePublisher.send(completion: Subscribers.Completion.failure(TestFailureCondition.anErrorExample))  <9>
     XCTAssertEqual(countValuesReceived, 2)
     XCTAssertEqual(countCompletionsReceived, 1)
 

--- a/docs/raw-notes.adoc
+++ b/docs/raw-notes.adoc
@@ -22,7 +22,7 @@ https://developer.apple.com/documentation/combine/publishers[Convenience publish
 
 [source,swift]
 ----
-enum sampleError: Error {
+enum SampleError: Error {
     case exampleError
 }
 
@@ -32,7 +32,7 @@ let x = Publishers.Future<String, Error> { promise in
           promise(.success(varname ? username : nil))
       }
   } catch {
-      promise(.failure(sampleError.exampleError))
+      promise(.failure(SampleError.exampleError))
   }
 }
 ----

--- a/docs/reference.adoc
+++ b/docs/reference.adoc
@@ -221,13 +221,13 @@ For example:
 Initializing `Fail` by specifying the types
 [source, swift]
 ----
-let cancellable = Fail<String, Error>(error: testFailureCondition.exampleFailure)
+let cancellable = Fail<String, Error>(error: TestFailureCondition.exampleFailure)
 ----
 
 Initializing `Fail` by providing types as parameters:
 [source, swift]
 ----
-let cancellable = Fail(outputType: String.self, failure: testFailureCondition.exampleFailure)
+let cancellable = Fail(outputType: String.self, failure: TestFailureCondition.exampleFailure)
 ----
 
 [#reference-sequence]
@@ -599,11 +599,11 @@ For example, if you have an object getting passed down that has a boolean proper
 
 [source, swift]
 ----
-struct myStruct {
+struct MyStruct {
     isValid: bool = true
 }
 //
-Just(myStruct())
+Just(MyStruct())
 .map { inValue -> Bool in <1>
   inValue.isValid <2>
 }
@@ -637,7 +637,7 @@ If you are looking at tryMap to decode JSON, you may want to consider using the 
 
 [source, swift]
 ----
-enum myFailure: Error {
+enum MyFailure: Error {
     case notBigEnough
 }
 
@@ -645,7 +645,7 @@ enum myFailure: Error {
 Just(5)
 .tryMap {
   if inValue < 5 { <1>
-      throw myFailure.notBigEnough <2>
+      throw MyFailure.notBigEnough <2>
   }
   return inValue <3>
 }
@@ -1254,7 +1254,7 @@ This can be illustrated with the following code snippet:
 
 [source, swift]
 ----
-enum testFailureCondition: Error {
+enum TestFailureCondition: Error {
     case invalidServerResponse
 }
 
@@ -1273,7 +1273,7 @@ let _ = simplePublisher
 
 simplePublisher.send("oneValue")
 simplePublisher.send("twoValue")
-simplePublisher.send(completion: Subscribers.Completion.failure(testFailureCondition.invalidServerResponse))
+simplePublisher.send(completion: Subscribers.Completion.failure(TestFailureCondition.invalidServerResponse))
 simplePublisher.send("redValue")
 simplePublisher.send("blueValue")
 simplePublisher.send(completion: .finished)
@@ -1624,7 +1624,7 @@ let remoteDataPublisher = urlSession.dataTaskPublisher(for: self.mockURL!)
     .tryMap { data, response -> Data in
         guard let httpResponse = response as? HTTPURLResponse,
             httpResponse.statusCode == 200 else {
-                throw testFailureCondition.invalidServerResponse
+                throw TestFailureCondition.invalidServerResponse
         }
         return data
     }
@@ -1896,7 +1896,7 @@ let _ = foo.$username
     .print(self.debugDescription)
     .tryMap({ myValue -> String in
         if (myValue == "boom") {
-            throw failureCondition.selfDestruct
+            throw FailureCondition.selfDestruct
         }
         return "mappedValue"
     })


### PR DESCRIPTION
Swift object types (e.g. `struct`, `class`, and `enum` should be title cased