### PR TITLE
Fix typo in reference.doc

### DIFF
--- a/docs/reference.adoc
+++ b/docs/reference.adoc
@@ -7,7 +7,7 @@ reference preamble goes here...
 ====
 This is intended to extend Apple's documentation, not replace it.
 
-* The documentation associated with IOS 13 GM.
+* The documentation associated with iOS 13 GM.
 
 things to potentially include for each segment
 
@@ -94,7 +94,7 @@ Instead, you should consider creating your own publisher based on <<reference#re
 
 [WARNING]
 ====
-As of Combine as it's released in IOS 13.2, Future is also somewhat incompatible with the retry operator.
+As of Combine as it's released in iOS 13.2, Future is also somewhat incompatible with the retry operator.
 The retry operator works by making another subscription to the publisher, and Future doesn't not currently re-invoke the closure you provide upon additional request demands.
 This means that chaining a retry() operator after future will not result in the Future's closure being invoked repeatedly when a `.failure` completion is returned.
 
@@ -483,7 +483,7 @@ let _ = foo.publisher(for: \.intValue)
 
 [NOTE]
 ====
-KVO publisher access implies that with MacOS 10.15 release or IOS 13, most of Appkit and UIKit interface instances will be accessible as publishers.
+KVO publisher access implies that with macOS 10.15 release or iOS 13, most of Appkit and UIKit interface instances will be accessible as publishers.
 Relying on the interface element's state to trigger updates into pipelines can lead to your state being very tightly bound to the interface elements, rather than your model.
 You may be better served by explicitly creating your own state to react to from a <<reference#reference-published,Published>> property wrapper.
 ====

--- a/docs/reference.adoc
+++ b/docs/reference.adoc
@@ -63,7 +63,7 @@ It's ideal for when you want to make a single request, or get a single response,
 
 The obvious example that everyone immediately thinks about is URLSession.
 Fortunately, <<reference#reference-datataskpublisher,URLSession.dataTaskPublisher>> exists to make a call with a URLSession and return a publisher.
-However, if you already have an API object that wraps the direct calls to URLSession, then making a single request using Future can great way to integrate the result into a Combine pipeline.
+However, if you already have an API object that wraps the direct calls to URLSession, then making a single request using Future can be a great way to integrate the result into a Combine pipeline.
 
 There are a number of other APIs that exist in the Apple frameworks that use a completion closure.
 An example of one is requesting permission to access the contacts store in Contacts.


### PR DESCRIPTION
> can great way to integrate

> IOS

> MacOS