### PR TITLE
adding a delay on error only test case illustrating it's operation

### DIFF
--- a/UsingCombineTests/RetryPublisherTests.swift
+++ b/UsingCombineTests/RetryPublisherTests.swift
@@ -145,4 +145,85 @@ class RetryPublisherTests: XCTestCase {
 
     }
 
+    func testRetryDelayOnFailureOnly() {
+        // setup
+        let expectation = XCTestExpectation(description: self.debugDescription)
+        var asyncAPICallCount = 0;
+        var futureClosureHandlerCount = 0;
+
+        let msTimeFormatter = DateFormatter()
+        msTimeFormatter.dateFormat = "[HH:mm:ss.SSSS] "
+
+        // example of a asynchronous function to be called from within a Future and its completion closure
+        func instrumentedAsyncAPICall(sabotage: Bool, completion completionBlock: @escaping ((Bool, Error?) -> Void)) {
+            DispatchQueue.global(qos: .background).async {
+                let delay = Int.random(in: 1...3)
+                print(msTimeFormatter.string(from: Date()) + " * starting async call (waiting \(delay) seconds before returning) ")
+                asyncAPICallCount+=1
+                sleep(UInt32(delay))
+                print(msTimeFormatter.string(from: Date()) + " * completing async call ")
+                if sabotage {
+                    completionBlock(false, TestFailureCondition.invalidServerResponse)
+                }
+                completionBlock(true, nil)
+            }
+        }
+
+        let upstreamPublisher = Deferred {
+            return Future<String, Error> { promise in
+                futureClosureHandlerCount += 1
+                // setting "sabotage: true" in the asyncAPICall tells the test code to return a
+                // failure result, which will illustrate "retry" better.
+                instrumentedAsyncAPICall(sabotage: true) { (grantedAccess, err) in
+                    // print("invoking async completion handler to return a resolved promise " + msTimeFormatter.string(from: Date()))
+                    // NOTE(heckj): the closure resolving the API call into a Promise result
+                    // is called far more than 3 times - 5 in this example, although I don't know
+                    // why that is. The underlying API call, and the closure within the future
+                    // are each called 3 times - validated below in the assertions.
+                    if let err = err {
+                        // print(" --> async call returned a failure")
+                        promise(.failure(err))
+                    } else {
+                        // print(" --> async call returned a success")
+                        promise(.success("allowed!"))
+                    }
+                }
+            }
+        }
+        .print("upstream publisher")
+        .eraseToAnyPublisher()
+
+        // this test is an idea proposed by anachev (ref: https://github.com/heckj/swiftui-notes/issues/164)
+        // on how to enable a "delay on error only". I have an example of using retry() with a random delay
+        // elsewhere in the book (https://heckj.github.io/swiftui-notes/#patterns-retry), but it *always*
+        // delays the call - which isn't an ideal solution.
+        let resultPublisher = upstreamPublisher.catch { error -> AnyPublisher<String, Error> in
+            print(msTimeFormatter.string(from: Date()) + "delaying on error for ~3 seconds ")
+            return Publishers.Delay(upstream: upstreamPublisher,
+                                    interval: 3,
+                                    tolerance: 1,
+                                    scheduler: DispatchQueue.global()).eraseToAnyPublisher()
+        }.retry(2)
+
+        XCTAssertEqual(asyncAPICallCount,0);
+        XCTAssertEqual(futureClosureHandlerCount,0);
+
+        let cancellable = resultPublisher.sink(receiveCompletion: { err in
+            print(msTimeFormatter.string(from: Date()) + ".sink() received the completion: ", String(describing: err))
+
+            // The surprise here is that the underlying asynchronous API call is made not 3 times, but 6 times.
+            // From the output in the test, which includes timestamps down to the ms to make it easier to see WHEN
+            // things are happening, the retry process ends up double-invoking the upstream publisher.
+            XCTAssertEqual(asyncAPICallCount, 6)
+            XCTAssertEqual(futureClosureHandlerCount, 6);
+            expectation.fulfill()
+        }, receiveValue: { value in
+            print(".sink() received value: ", value)
+            XCTFail("no value should be returned")
+        })
+
+        wait(for: [expectation], timeout: 30.0)
+        XCTAssertNotNil(cancellable)
+    }
+
 }


### PR DESCRIPTION
test example associated with #164 

Output from the associated test:

```
[12:25:59.5170]  * starting async call (waiting 1 seconds before returning) 
[12:26:00.6100]  * completing async call 
[12:26:00.6130] delaying on error for ~3 seconds 
[12:26:00.6130]  * starting async call (waiting 1 seconds before returning) 
[12:26:01.7090]  * completing async call 
[12:26:04.7940]  * starting async call (waiting 1 seconds before returning) 
[12:26:05.8100]  * completing async call 
[12:26:05.8100] delaying on error for ~3 seconds 
[12:26:05.8110]  * starting async call (waiting 3 seconds before returning) 
[12:26:08.9090]  * completing async call 
[12:26:11.9560]  * starting async call (waiting 2 seconds before returning) 
[12:26:14.0460]  * completing async call 
[12:26:14.0470] delaying on error for ~3 seconds 
[12:26:14.0470]  * starting async call (waiting 3 seconds before returning) 
[12:26:17.1420]  * completing async call 
[12:26:20.2270] .sink() received the completion:  failure(UsingCombineTests.RetryPublisherTests.TestFailureCondition.invalidServerResponse)
```