### PR TITLE
Update info about iOS 13 Combine framework changes; correct typos

### DIFF
--- a/docs/aboutthisbook.adoc
+++ b/docs/aboutthisbook.adoc
@@ -82,8 +82,8 @@ The content for this book, including sample code and tests, are sourced from the
 === Download the project
 
 The contents of this book, as well as example code and unit tests referenced from the book, are linked in an Xcode project (`SwiftUI-Notes.xcodeproj`).
-the Xcode project includes fully operational sample code that shows examples of Combine integrating with UIKit and SwiftUI.
-The project also includes extensive unit tests excercising the framework to illustrate the behavior of framework components.
+The Xcode project includes fully operational sample code that shows examples of Combine integrating with UIKit and SwiftUI.
+The project also includes extensive unit tests exercising the framework to illustrate the behavior of framework components.
 
 The project associated with this book requires Xcode 11 and MacOS 10.14 or later.
 

--- a/docs/coreconcepts.adoc
+++ b/docs/coreconcepts.adoc
@@ -272,12 +272,12 @@ Each operator in turn accepting the request for data and in turn requesting info
 
 [NOTE]
 ====
-In the first release of the Combine framework - in IOS 13 prior to IOS 13.2, macOS 10.15 Catalina, when the subscriber requested data with a Demand, that call itself was asynchronous.
+In the first release of the Combine framework - in iOS 13 prior to iOS 13.3 and macOS prior to 10.15.2 - when the subscriber requested data with a Demand, that call itself was asynchronous.
 Because this process acted as the driver which triggered attached operators and ultimately the source publisher, it meant that there were scenarios where data might appear to be lost.
-Due to this, in IOS 13.2 and later combine releases, the process of requesting demand has been updated to a synchronous/blocking call.
-In practice, this means that you can be a bit more certain of having any pipelines created and full engaged prior to a publisher receiving the request to send any data.
+Due to this, in iOS 13.3 and later Combine releases, the process of requesting demand has been updated to a synchronous/blocking call.
+In practice, this means that you can be a bit more certain of having any pipelines created and fully engaged prior to a publisher receiving the request to send any data.
 
-There is an https://forums.swift.org/t/combine-receive-on-runloop-main-loses-sent-value-how-can-i-make-it-work/28631/39[extended thread on the swift forums] about this topic, if you are interested in reading the history.
+There is an https://forums.swift.org/t/combine-receive-on-runloop-main-loses-sent-value-how-can-i-make-it-work/28631/39[extended thread on the Swift forums] about this topic, if you are interested in reading the history.
 ====
 
 With the subscriber driving this process, it allows Combine to support cancellation.

--- a/docs/coreconcepts.adoc
+++ b/docs/coreconcepts.adoc
@@ -13,7 +13,7 @@ These core concepts are:
 [#coreconcepts-publisher-subscriber]
 == Publisher and Subscriber
 
-Two key concepts: https://developer.apple.com/documentation/combine/publisher[*publisher*] and https://developer.apple.com/documentation/combine/subscriber[*subscriber*] are described in Swift as protocols.
+Two key concepts, https://developer.apple.com/documentation/combine/publisher[*publisher*] and https://developer.apple.com/documentation/combine/subscriber[*subscriber*], are described in Swift as protocols.
 
 When you are talking about programming (and especially with Swift and Combine), quite a lot is described by the types.
 When you say a function or method returns a value, that value is generally described as being "one of this type".
@@ -59,7 +59,7 @@ image::diagrams/pipeline.svg[pipeline]
 Operators can be used to transform either values or types - both the Output and Failure type.
 Operators may also split or duplicate streams, or merge streams together.
 Operators must always be aligned by the combination of Output/Failure types.
-The compiler will enforce the matching types, so getting it wrong will result in a compiler error (and if you are lucky - a useful _fixit_ snippet suggesting a solution).
+The compiler will enforce the matching types, so getting it wrong will result in a compiler error (and, if you are lucky, a useful _fixit_ snippet suggesting a solution).
 
 A simple Combine pipeline written in swift might look like:
 [source, swift]
@@ -77,7 +77,7 @@ let _ = Just(5) <1>
 ----
 
 <1> The pipeline starts with the publisher `Just`, which responds with the value that its defined with (in this case, the Integer `5`). The output type is `<Integer>`, and the failure type is `<Never>`.
-<2> the pipeline then has a `map` operator, which is transforming the value and its type.
+<2> The pipeline then has a `map` operator, which is transforming the value and its type.
 In this example it is ignoring the published input and returning a string.
 This is also transforming the output type to `<String>`, and leaving the failure type still set as `<Never>`.
 <3> The pipeline then ends with a `sink` subscriber.
@@ -236,7 +236,7 @@ The input type for this map operator is `<Int>`, which is described with generic
 The failure type that is being passed to this operator is `<Never>`, described in the same syntax just below the Input type.
 
 The map operator doesn't change or interact with the failure type, only passing it along.
-To represent that, the failure types - both input (above) and output (below) have been lightened.
+To represent that, the failure types - both input (above) and output (below) - have been lightened.
 
 A single input value provided (`5`) is represented on the top line.
 The location on the line isn't meaningful in this case, only representing that it is a single value.
@@ -297,10 +297,10 @@ The end to end lifecycle is enabled by subscribers and publishers communicating 
 
 .An The lifecycle of a combine pipeline
 image::diagrams/combine_lifecycle_diagram.svg[combine lifecycle diagram]
-<1> When the subscriber is attached to a publisher, it starts with a call to `.subscribe(Subscriber)`.
-<2> The publisher in turn acknowledges the subscription calling `receive(subscription)`.
-<3> After the subscription has been acknowledged, the subscriber requests _N_ values with `request(_ : Demand)`.
-<4> The publisher may then (as it has values) send _N_ (or fewer) values using `receive(_ : Input)`.
+<1> When the subscriber is attached to a publisher, it starts with a call to `.subscribe(_: Subscriber)`.
+<2> The publisher in turn acknowledges the subscription calling `receive(subscription: Subscription)`.
+<3> After the subscription has been acknowledged, the subscriber requests _N_ values with `request(_: Demand)`.
+<4> The publisher may then (as it has values) send _N_ (or fewer) values using `receive(_: Input)`.
 A publisher should never send **more** than the demand requested.
 <5> Any time after the subscription has been acknowledged, the subscriber may send a https://developer.apple.com/documentation/combine/subscribers/completion[cancellation] with `.cancel()`
 <6> A publisher may optionally send https://developer.apple.com/documentation/combine/subscribers/completion[completion]: `receive(completion:)`.
@@ -340,8 +340,8 @@ Combine provides a number of additional convenience publishers:
 | <<reference#reference-fail,Fail>>
 
 | <<reference#reference-record,Record>>
-| <<reference#reference-share>>
-| <<reference#reference-multicast>>
+| <<reference#reference-share,Share>>
+| <<reference#reference-multicast,Multicast>>
 
 | <<reference#reference-observableobject,ObservableObject>>
 | <<reference#reference-published,@Published>>
@@ -527,23 +527,24 @@ Operators can also be used to define error handling and retry logic, buffering a
 [#coreconcepts-subjects]
 == Subjects
 
-Subjects are a special case of publisher that also adhere to the https://developer.apple.com/documentation/combine/subject[`subject`] protocol.
-This protocol requires subjects to have a `.send()` method to allow the developer to send specific values to a subscriber (or pipeline).
+Subjects are a special case of publisher that also adhere to the https://developer.apple.com/documentation/combine/subject[`Subject`] protocol.
+This protocol requires subjects to have a `.send(_:)` method to allow the developer to send specific values to a subscriber (or pipeline).
 
-Subjects can be used to "inject" values into a stream, by calling the subject's `.send()` method.
+Subjects can be used to "inject" values into a stream, by calling the subject's `.send(_:)` method.
 This is useful for integrating existing imperative code with Combine.
 
 A subject can also broadcast values to multiple subscribers.
-If multiple subscribers are connected to a subject, it will fan out values to the multiple subscribers when `send()` is invoked.
+If multiple subscribers are connected to a subject, it will fan out values to the multiple subscribers when `send(_:)` is invoked.
 A subject is also frequently used to connect or cascade multiple pipelines together, especially to fan out to multiple pipelines.
 
-A subject does not blindly pass through the demand from its subscribers, instead it provides an aggregation point for demand.
+A subject does not blindly pass through the demand from its subscribers.
+Instead, it provides an aggregation point for demand.
 A subject will not signal for demand to its connected publishers until it has received at least one subscriber itself.
 When it receives any demand, it then signals for `unlimited` demand to connected publishers.
 With the subject supporting multiple subscribers, any subscribers that have not requested data with a demand are not provided the data until they do.
 
-There are two types of built-in subjects with Combine: <<reference#reference-currentvaluesubject,currentValueSubject>> and <<reference#reference-passthroughsubject,passthroughSubject>>.
-They act similiarly, the difference being currentValueSubject remembers and requires an initial state, where passthroughSubject does not.
+There are two types of built-in subjects with Combine: <<reference#reference-currentvaluesubject,CurrentValueSubject>> and <<reference#reference-passthroughsubject,PassthroughSubject>>.
+They act similiarly, the difference being CurrentValueSubject remembers and requires an initial state, where PassthroughSubject does not.
 Both will provide updated values to any subscribers when `.send()` is invoked.
 
 Both `CurrentValueSubject` and `PassthroughSubject` are also useful for creating publishers for objects conforming to https://developer.apple.com/documentation/combine/observableobject[`ObservableObject`].
@@ -552,19 +553,19 @@ This protocol is supported by a number of declarative components within SwiftUI.
 [#coreconcepts-subscribers]
 == Subscribers
 
-While https://developer.apple.com/documentation/combine/subscriber[`subscriber`] is the protocol used to receive data throughout a pipeline, _the subscriber_ typically refers to the end of a pipeline.
+While https://developer.apple.com/documentation/combine/subscriber[`Subscriber`] is the protocol used to receive data throughout a pipeline, _the subscriber_ typically refers to the end of a pipeline.
 
-There are two subscribers built-in to Combine: <<reference#reference-assign,assign>> and <<reference#reference-sink,sink>>.
+There are two subscribers built-in to Combine: <<reference#reference-assign,Assign>> and <<reference#reference-sink,Sink>>.
 There is a subscriber built in to SwiftUI: <<reference#reference-onreceive,onReceive>>.
 
 Subscribers can support cancellation, which terminates a subscription and shuts down all the stream processing prior to any Completion sent by the publisher.
-Both `Assign` and `Sink` conform to the https://developer.apple.com/documentation/combine/cancellable[cancellable protocol].
+Both `Assign` and `Sink` conform to the https://developer.apple.com/documentation/combine/cancellable[Cancellable protocol].
 
 When you are storing a reference to your own subscriber in order to clean up later, you generally want a reference to cancel the subscription.
-<<reference#reference-anycancellable,anyCancellable>> provides a type-erased reference that converts any subscriber to the type AnyCancellable, allowing the use of `.cancel()` on that reference, but not access to the subscription itself (which could, for instance, request more data).
+<<reference#reference-anycancellable,AnyCancellable>> provides a type-erased reference that converts any subscriber to the type AnyCancellable, allowing the use of `.cancel()` on that reference, but not access to the subscription itself (which could, for instance, request more data).
 It is important to store a reference to the subscriber, as when the reference is deallocated it will implicitly cancel its operation.
 
-https://developer.apple.com/documentation/combine/subscribers/assign[`assign`] applies values passed down from the publisher to an object defined by a keypath.
+https://developer.apple.com/documentation/combine/subscribers/assign[`Assign`] applies values passed down from the publisher to an object defined by a keypath.
 The keypath is set when the pipeline is created.
 An example of this in Swift might look like:
 
@@ -573,7 +574,7 @@ An example of this in Swift might look like:
 .assign(to: \.isEnabled, on: signupButton)
 ----
 
-https://developer.apple.com/documentation/combine/subscribers/sink[`sink`] accepts a closure that receives any resulting values from the publisher.
+https://developer.apple.com/documentation/combine/subscribers/sink[`Sink`] accepts a closure that receives any resulting values from the publisher.
 This allows the developer to terminate a pipeline with their own code.
 This subscriber is also extremely helpful when writing unit tests to validate either publishers or pipelines.
 An example of this in Swift might look like:
@@ -606,7 +607,7 @@ struct MyView : View {
 }
 ----
 
-For any type of UI object (UIKit, AppKit, or SwiftUI), <<reference#reference-assign,assign>> can be used with pipelines to update properties.
+For any type of UI object (UIKit, AppKit, or SwiftUI), <<reference#reference-assign,Assign>> can be used with pipelines to update properties.
 
 // force a page break - ignored in HTML rendering
 <<<

--- a/docs/developingwith.adoc
+++ b/docs/developingwith.adoc
@@ -17,7 +17,7 @@ These publishers are expected to create a single response (or perhaps no respons
 
 The second is what I'm calling a "continuous" publisher.
 These publishers and associated pipelines are expected to be always active and providing the means to respond to ongoing events.
-In this case, the lifetime of the pipeline is significant longer, and it is often not desirable to have such pipelines fail or terminate.
+In this case, the lifetime of the pipeline is significantly longer, and it is often not desirable to have such pipelines fail or terminate.
 
 When you are thinking about your development and how to use Combine, it is often beneficial to think about pipelines as being one of these types, and mixing them together to achieve your goals.
 For example, the pattern <<patterns#patterns-continual-error-handling,Using flatMap with catch to handle errors>> explicitly uses one-shot pipelines to support error handling on a continual pipeline.
@@ -25,7 +25,7 @@ For example, the pattern <<patterns#patterns-continual-error-handling,Using flat
 When you are creating an instance of a publisher or a pipeline, it is worthwhile to be thinking about how you want it to work - to either be a one-shot, or continous.
 This choice will inform how you handle errors or if you want to deal with operators that manipulate the timing of the events (such as <<reference#reference-debounce,debounce>> or <<reference#reference-throttle,throttle>>).
 
-In addition to how much data the pipeline or publisher will provide you will often want to think about what type pair the pipeline is expected to provide.
+In addition to how much data the pipeline or publisher will provide, you will often want to think about what type pair the pipeline is expected to provide.
 A number of pipelines are more about transforming data through various types, and handling possible error conditions in that processing.
 An example of this is returning a pipeline returning a list in the example <<patterns#patterns-update-interface-userinput,Declarative UI updates from user input>> to provide a means to represent an "empty" result, even though the list is never expected to have more than 1 item within it.
 
@@ -71,10 +71,10 @@ The two classes used to expose simplified types for subscribers and publishers a
 * https://developer.apple.com/documentation/combine/anysubscriber[AnySubscriber]
 * https://developer.apple.com/documentation/combine/anypublisher[AnyPublisher]
 
-Most publishers also include a convenience method `eraseToAnyPublisher` that returns an instance of AnyPublisher.
-`eraseToAnyPublisher` is used very much like an operator, often as the last element in a chained pipeline, to simplify the type returned.
+Every publisher also inherits a convenience method `eraseToAnyPublisher()` that returns an instance of AnyPublisher.
+`eraseToAnyPublisher()` is used very much like an operator, often as the last element in a chained pipeline, to simplify the type returned.
 
-If you updated the above code to add .eraseToAnyPublisher() at the end of the pipeline:
+If you updated the above code to add `.eraseToAnyPublisher()` at the end of the pipeline:
 
 [source, swift]
 ----


### PR DESCRIPTION
This PR clarifies the version information around the change to `receive(on:)` synchronicity in an iOS point release. Specifically, the linked Swift thread says the change was first released in iOS 13.3 and macOS 10.15.2; this PR updates the text to make these versions clear.

The other changes are all very minor typos, grammar corrections, or capitalization fixes. Thanks for all your work!