### PR TITLE
Multicast/Share idiosyncracies

### DIFF
--- a/UsingCombineTests/MulticastSharePublisherTests.swift
+++ b/UsingCombineTests/MulticastSharePublisherTests.swift
@@ -11,20 +11,27 @@ import Combine
 
 class MulticastSharePublisherTests: XCTestCase {
 
+    var sourceValue = 0
+
+    func sourceGenerator() -> Int {
+      sourceValue += 1
+      return sourceValue
+    }
+
     enum TestFailureCondition: Error {
         case anErrorExample
     }
 
     // example of a asynchronous function to be called from within a Future and its completion closure
-    func asyncAPICall(sabotage: Bool, completion completionBlock: @escaping ((Bool, Error?) -> Void)) {
+    func asyncAPICall(sabotage: Bool, completion completionBlock: @escaping ((Int, Error?) -> Void)) {
         DispatchQueue.global(qos: .background).async {
             let delay = Int.random(in: 1...3)
             print(" * making async call (delay of \(delay) seconds)")
             sleep(UInt32(delay))
             if sabotage {
-                completionBlock(false, TestFailureCondition.anErrorExample)
+                completionBlock(0, TestFailureCondition.anErrorExample)
             }
-            completionBlock(true, nil)
+          completionBlock(self.sourceGenerator(), nil)
         }
     }
 
@@ -34,7 +41,7 @@ class MulticastSharePublisherTests: XCTestCase {
 
         // the creating the deferred, future publisher
         let pub = Deferred {
-            Future<Bool, Error> { promise in
+            Future<Int, Error> { promise in
                 self.asyncAPICall(sabotage: false) { (grantedAccess, err) in
                     if let err = err {
                         promise(.failure(err))
@@ -60,12 +67,16 @@ class MulticastSharePublisherTests: XCTestCase {
 
     func testSharedDeferredFuturePublisher() {
         // setup
-        let expectation1 = XCTestExpectation(description: self.debugDescription)
-        let expectation2 = XCTestExpectation(description: self.debugDescription)
+        let firstCompletion = XCTestExpectation(description: self.debugDescription)
+        firstCompletion.expectedFulfillmentCount = 2
+
+        let secondCompletion = expectation(description: self.debugDescription)
+        let secondValue = expectation(description: self.debugDescription)
+        secondValue.isInverted = true
 
         // the creating the deferred, future publisher
         let pub = Deferred {
-            Future<Bool, Error> { promise in
+            Future<Int, Error> { promise in
                 self.asyncAPICall(sabotage: false) { (grantedAccess, err) in
                     if let err = err {
                         promise(.failure(err))
@@ -79,39 +90,67 @@ class MulticastSharePublisherTests: XCTestCase {
         // such that any number of subscribers can ask for a resource, and it will translate
         // that into a single request - only one subscription being made 'upstream'
 
+        var sinkValues = [Int]()
+
         let otherCancellable = pub.sink(receiveCompletion: { completion in
             print(".sink() received the completion: ", String(describing: completion))
-            expectation1.fulfill()
+            firstCompletion.fulfill()
         }, receiveValue: { value in
             print(".sink() received value: ", value)
+            sinkValues.append(value)
         })
 
         // driving it by attaching it to .sink
         let cancellable = pub.sink(receiveCompletion: { completion in
             print(".sink() received the completion: ", String(describing: completion))
-            expectation2.fulfill()
+            firstCompletion.fulfill()
         }, receiveValue: { value in
             print(".sink() received value: ", value)
-
+            sinkValues.append(value)
         })
 
-        wait(for: [expectation1, expectation2], timeout: 5.0)
+        wait(for: [firstCompletion], timeout: 5.0)
+
+        // drive the publisher again.
+        // Note that we won't receive a value this time, just the completion.
+        let thirdCancellable = pub.sink(receiveCompletion: { completion in
+            print(".sink() received the completion: ", String(describing: completion))
+            secondCompletion.fulfill()
+        }, receiveValue: { value in
+            print(".sink() received value: ", value)
+            sinkValues.append(value)
+            secondValue.fulfill()
+        })
+
+        wait(for: [secondCompletion, secondValue], timeout: 5.0)
+
+        XCTAssertEqual(sinkValues.count, 2)
+        XCTAssertEqual(sinkValues[0], sinkValues[1])
         XCTAssertNotNil(cancellable)
         XCTAssertNotNil(otherCancellable)
+        XCTAssertNotNil(thirdCancellable)
     }
 
     func testMulticastDeferredFuturePublisher() {
         // setup
-        let expectation1 = XCTestExpectation(description: self.debugDescription)
-        let expectation2 = XCTestExpectation(description: self.debugDescription)
+        let firstCompletion = XCTestExpectation(description: self.debugDescription)
+        let firstValues = XCTestExpectation(description: self.debugDescription)
+        firstCompletion.expectedFulfillmentCount = 2
+        firstValues.expectedFulfillmentCount = 2
 
-        let pipelineFork = PassthroughSubject<Bool, Error>()
+        let secondCompletion = expectation(description: self.debugDescription)
+        let secondValue = expectation(description: self.debugDescription)
+        secondValue.isInverted = true
+
+        let pipelineFork = PassthroughSubject<Int, Error>()
 
         var cancellables = Set<AnyCancellable>()
 
+        var sinkValues = [Int]()
+
         // the creating the deferred, future publisher
         let publisher = Deferred {
-            Future<Bool, Error> { promise in
+            Future<Int, Error> { promise in
                 self.asyncAPICall(sabotage: false) { (grantedAccess, err) in
                     if let err = err {
                         promise(.failure(err))
@@ -125,18 +164,22 @@ class MulticastSharePublisherTests: XCTestCase {
         publisher
             .sink(receiveCompletion: { completion in
                 print(".sink() received the completion: ", String(describing: completion))
-                expectation1.fulfill()
+                firstCompletion.fulfill()
             }, receiveValue: { value in
                 print(".sink() received value: ", value)
+                sinkValues.append(value)
+                firstValues.fulfill()
             })
             .store(in: &cancellables)
 
         // driving it by attaching it to .sink
         publisher.sink(receiveCompletion: { completion in
             print(".sink() received the completion: ", String(describing: completion))
-            expectation2.fulfill()
+            firstCompletion.fulfill()
         }, receiveValue: { value in
             print(".sink() received value: ", value)
+            sinkValues.append(value)
+            firstValues.fulfill()
         })
         .store(in: &cancellables)
 
@@ -144,7 +187,24 @@ class MulticastSharePublisherTests: XCTestCase {
             .connect()
             .store(in: &cancellables)
 
-        wait(for: [expectation1, expectation2], timeout: 5.0)
+        wait(for: [firstCompletion, firstValues], timeout: 5.0)
+        XCTAssertEqual(sinkValues.count, 2)
+        XCTAssertEqual(sinkValues[0], sinkValues[1])
+
+        // Our latecoming subscriber
+        publisher.sink(receiveCompletion: { completion in
+            print(".sink() received the completion: ", String(describing: completion))
+            secondCompletion.fulfill()
+        }, receiveValue: { value in
+            print(".sink() received value: ", value)
+            sinkValues.append(value)
+            secondValue.fulfill()
+        })
+        .store(in: &cancellables)
+
+        // We won't need to wait long, as the completion should be immediate
+        wait(for: [secondCompletion, secondValue], timeout: 1.0)
+        XCTAssertEqual(sinkValues.count, 2)
     }
 
     func testAltMulticastDeferredFuturePublisher() {
@@ -156,7 +216,7 @@ class MulticastSharePublisherTests: XCTestCase {
 
         // the creating the deferred, future publisher
         let publisher = Deferred {
-            Future<Bool, Error> { promise in
+            Future<Int, Error> { promise in
                 self.asyncAPICall(sabotage: false) { (grantedAccess, err) in
                     if let err = err {
                         promise(.failure(err))
@@ -167,7 +227,7 @@ class MulticastSharePublisherTests: XCTestCase {
             }
         }.multicast {
             // alternate way of using multicast that creates the relevant subject inline
-            PassthroughSubject<Bool, Error>()
+            PassthroughSubject<Int, Error>()
         }
 
         publisher

--- a/UsingCombineTests/MulticastSharePublisherTests.swift
+++ b/UsingCombineTests/MulticastSharePublisherTests.swift
@@ -261,36 +261,101 @@ class MulticastSharePublisherTests: XCTestCase {
 
     func testMakeConnectable() {
         // setup
-        let expectation1 = XCTestExpectation(description: self.debugDescription)
-        let expectation2 = XCTestExpectation(description: self.debugDescription)
+        let firstCompletion = expectation(description: self.debugDescription)
+
+        let values = expectation(description: self.debugDescription)
+        values.expectedFulfillmentCount = 4
+
+        let waiting = expectation(description: self.debugDescription)
+
         var cancellables = Set<AnyCancellable>()
 
-        let publisher = Just("woot")
+        let publisher = [1,2].publisher
             .makeConnectable()
 
         // driving it by attaching it to .sink
         publisher.sink(receiveCompletion: { completion in
             print(".sink1() received the completion: ", String(describing: completion))
-            expectation1.fulfill()
+            firstCompletion.fulfill()
         }, receiveValue: { value in
             print(".sink1() received value: ", value)
+            values.fulfill()
         })
         .store(in: &cancellables)
+
+        // Setup the order in our wait. The first completion won't have ooccured yet.
+        waiting.fulfill()
+
+        let autoPublisher = publisher.autoconnect()
 
         // driving it by attaching it to .sink
-        publisher.sink(receiveCompletion: { completion in
+        autoPublisher.sink(receiveCompletion: { completion in
             print(".sink2() received the completion: ", String(describing: completion))
-            expectation2.fulfill()
         }, receiveValue: { value in
             print(".sink2() received value: ", value)
+            values.fulfill()
         })
         .store(in: &cancellables)
 
-        publisher
-            .connect()
-            .store(in: &cancellables)
-
-        wait(for: [expectation1, expectation2], timeout: 5.0)
+        // We should have fulfilled our mock "setup" before anyone received values
+        wait(for: [waiting, values, firstCompletion], timeout: 5.0, enforceOrder: true)
     }
 
+    // As the makeConnectable example above, but now with MultiCast we can include an error
+    // Setup a "pipeline" inspector before handing the publisher back to the unsuspecting
+    // original subscriber
+
+    func testMulticastDeferredFutureAutoConnectPublisher() {
+        // setup
+        let doSomeSpyWork = expectation(description: self.debugDescription)
+        let legitCompletion = expectation(description: self.debugDescription)
+        let spyCompletion = expectation(description: self.debugDescription)
+        let spyValueReceived = expectation(description: self.debugDescription)
+        let legitValueReceived = expectation(description: self.debugDescription)
+
+        var cancellables = Set<AnyCancellable>()
+
+        // the creating the deferred, future publisher
+        let publisher = Deferred {
+            Future<Int, Error> { promise in
+                self.asyncAPICall(sabotage: false) { (grantedAccess, err) in
+                    if let err = err {
+                        promise(.failure(err))
+                    } else {
+                        promise(.success(grantedAccess))
+                    }
+                }
+            }
+        }.multicast {
+            // alternate way of using multicast that creates the relevant subject inline
+            PassthroughSubject<Int, Error>()
+        }
+
+        // Attach our 'spy' subscriber. The publisher won't receive a 'send' .... yet
+        publisher.sink(receiveCompletion: { completion in
+            print(".sink() received the completion: ", String(describing: completion))
+            spyCompletion.fulfill()
+        }, receiveValue: { value in
+            print(".sink() received value: ", value)
+            spyValueReceived.fulfill()
+        })
+        .store(in: &cancellables) // Note: the spy needs to keep a reference to his own subscriber
+
+        // Our spy has some work to do now before hands back the intercepted publisher
+        doSomeSpyWork.fulfill()
+
+        // Now hand off the publisher to the real subscriber
+        let spyedPublisher = publisher.autoconnect()
+        spyedPublisher.sink(receiveCompletion: { completion in
+            print(".sink() received the completion: ", String(describing: completion))
+            legitCompletion.fulfill()
+        }, receiveValue: { value in
+            print(".sink() received value: ", value)
+            legitValueReceived.fulfill()
+        })
+        .store(in: &cancellables)
+
+        wait(for: [doSomeSpyWork, spyValueReceived], timeout: 5.0, enforceOrder: true)
+        wait(for: [legitValueReceived, legitCompletion, spyCompletion], timeout: 5.0)
+    }
 }


### PR DESCRIPTION
Hey Mate,

I just forked your repository to illustrate a use-case for multicast/share, where you can insert a subscriber into a system that's already working. 

I used this in one of my projects to intercept all requests to DataTask and cache the results, concurrently and independently to the subscriber in my ViewModels. I didn't have to co-ordinate a call to connect or anything like that.

In addition I didn't realise (for quite some time) that you could subscribe to a 'share' or multicast and if you missed the value (because the original subscriber called send before your intercept code was ready), then it was just too bad, but you still received a 'completion'!

Anyway, I am aware I haven't conformed to your current coding style etc. If you're interested I can tidy it up/conform prior to merging, but I didn't want to do the work if I've just figured out something dumb .... or more likely, you point out the massive glaring problem with what I've done!

Thanks for the book/repo anyway, it's always kept handy when I'm coding!

Will.