### PR TITLE
fix grammar

### DIFF
--- a/docs/reference.adoc
+++ b/docs/reference.adoc
@@ -2505,7 +2505,7 @@ For example, if combineLatest was used to merge a publisher with the output type
 `CombineLatest` is most often used with continual publishers, and remembering the last output value provided from each publisher.
 In turn, when any of the upstream publishers sends an updated value, the operator makes a new combined tuple of all previous "current" values, adds in the new value in the correct place, and sends that new combined value down the pipeline.
 
-The failure type of all three upstream publishers needs to be the identical.
+The failure types of all three upstream publishers need to be identical.
 For example, you can not have one publisher that has a failure type of `Error` and another (or more) that have a failure type of `Never`.
 If the `combineLatest` operator does receive a failure from any of the upstream publishers, then the operator (and the rest of the pipeline) is cancelled after propagating that failure.
 


### PR DESCRIPTION
Essentially I only wanted to fix the superfluous ` the`.  

I think `The failure type of all three upstream publishers needs` can be kept if you replace `identical` with `the same`.   
I'll leave that up to you. I can also try and explain why I felt that `The failure types of all three upstream publishers need` would be more appropriate, if you want me to (I might be wrong, though ^^).
